### PR TITLE
[SofaImGui] Load reload simulation

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -112,7 +112,8 @@ protected:
     void applyDarkMode(const bool &darkMode, sofaglfw::SofaGLFWBaseGUI* baseGUI=nullptr);
 
     void saveSettings();
-    void reloadSimulation();
+    void loadSimulation(const bool& reload, const std::string &filename);
+    void clearGUI();
 
     models::IPController::SPtr m_IPController;
     models::SimulationState m_simulationState;

--- a/SofaImGui/src/SofaImGui/Utils.cpp
+++ b/SofaImGui/src/SofaImGui/Utils.cpp
@@ -27,13 +27,15 @@
 
 namespace sofaimgui::Utils {
 
-void loadFile(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool& reload, const std::string filePathName)
+static bool withArguments = true;
+
+void loadFile(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool& reload, const std::string &filePathName)
 {
     if (baseGUI && !filePathName.empty() && sofa::helper::system::FileSystem::exists(filePathName))
     {
         sofa::core::sptr<sofa::simulation::Node> groot = baseGUI->getRootNode();
         sofa::simulation::node::unload(groot);
-        const std::vector<std::string> sceneArgs = sofa::gui::common::ArgumentParser::extra_args();
+        const std::vector<std::string> sceneArgs = (reload && withArguments)? sofa::gui::common::ArgumentParser::extra_args(): std::vector<std::string>(0);
 
         groot = sofa::simulation::node::load(filePathName.c_str(), reload, sceneArgs);
         if(!groot)
@@ -77,9 +79,11 @@ void resetSimulationView(sofaglfw::SofaGLFWBaseGUI *baseGUI)
     }
 }
 
-void reloadSimulation(sofaglfw::SofaGLFWBaseGUI *baseGUI, const std::string filePathName)
+void loadSimulation(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool& reload, const std::string& filePathName)
 {
-    loadFile(baseGUI, true, filePathName);
+    if(!reload)
+        withArguments = false; // Forget python arguments once the user opens a new simulation from the GUI
+    loadFile(baseGUI, reload, filePathName);
     resetSimulationView(baseGUI);
 }
 

--- a/SofaImGui/src/SofaImGui/Utils.h
+++ b/SofaImGui/src/SofaImGui/Utils.h
@@ -25,9 +25,9 @@
 
 namespace sofaimgui::Utils {
 
-void loadFile(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool &reload, const std::string filePathName);
+void loadFile(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool &reload, const std::string& filePathName);
 void resetSimulationView(sofaglfw::SofaGLFWBaseGUI *baseGUI);
-void reloadSimulation(sofaglfw::SofaGLFWBaseGUI *baseGUI, const std::string filePathName);
+void loadSimulation(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool& reload, const std::string& filePathName);
 
 enum CameraAlignement{TOP, BOTTOM, LEFT, RIGHT, FRONT, BACK};
 void alignCamera(sofaglfw::SofaGLFWBaseGUI *baseGUI, const CameraAlignement &align);

--- a/SofaImGui/src/SofaImGui/menus/FileMenu.cpp
+++ b/SofaImGui/src/SofaImGui/menus/FileMenu.cpp
@@ -43,21 +43,22 @@ FileMenu::~FileMenu()
 {
 }
 
-bool FileMenu::addMenu()
+void FileMenu::addMenu()
 {
-    if (m_baseGUI == nullptr)
-        return false;
+    m_loadSimulation = false;
+    m_reloadSimulation = false;
 
-    bool loadSimulation = false;
+    if (m_baseGUI == nullptr)
+        return;
 
     ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 1.f, 1.f, 1.f));
     if (ImGui::BeginMenu("File"))
     {
         ImGui::PopStyleColor();
         if(addOpenSimulation())
-            loadSimulation = true;
+            m_loadSimulation = true;
         if(addReloadSimulation())
-            loadSimulation = true;
+            m_reloadSimulation = true;
 
         ImGui::Separator();
 
@@ -74,7 +75,7 @@ bool FileMenu::addMenu()
         ImGui::PopStyleColor();
     }
 
-    return loadSimulation;
+    return;
 }
 
 bool FileMenu::addOpenSimulation()

--- a/SofaImGui/src/SofaImGui/menus/FileMenu.h
+++ b/SofaImGui/src/SofaImGui/menus/FileMenu.h
@@ -33,10 +33,13 @@ class FileMenu
     FileMenu(sofaglfw::SofaGLFWBaseGUI* baseGUI);
     ~FileMenu();
 
-    bool addMenu();
+    void addMenu();
     const std::string& getFilename() const {return m_filename;}
 
     sofaglfw::SofaGLFWBaseGUI * m_baseGUI;
+
+    bool m_loadSimulation{false};
+    bool m_reloadSimulation{false};
 
    protected:
 

--- a/SofaImGui/src/SofaImGui/models/SimulationState.cpp
+++ b/SofaImGui/src/SofaImGui/models/SimulationState.cpp
@@ -25,7 +25,7 @@
 namespace sofaimgui::models {
 
 
-void SimulationState::clearStateData()
+void SimulationState::clearData()
 {
     m_stateData.clear();
 }

--- a/SofaImGui/src/SofaImGui/models/SimulationState.h
+++ b/SofaImGui/src/SofaImGui/models/SimulationState.h
@@ -42,7 +42,7 @@ class SOFAIMGUI_API SimulationState
     SimulationState() = default;
     ~SimulationState() = default;
 
-    void clearStateData();
+    void clearData();
     void addStateData(StateData &data);
     const std::vector<StateData>& getStateData() const;
 

--- a/SofaImGui/src/SofaImGui/windows/BaseWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/BaseWindow.cpp
@@ -23,4 +23,11 @@
 
 namespace sofaimgui::windows {
 
+bool& BaseWindow::isOpen()
+{
+    if (!enabled())
+        m_isOpen = false;
+    return m_isOpen;
+}
+
 }

--- a/SofaImGui/src/SofaImGui/windows/BaseWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/BaseWindow.h
@@ -40,6 +40,13 @@ class SOFAIMGUI_API BaseWindow
     /// Set the window as able to drive the robot in simulation.
     virtual void setDrivingTCPTarget(const bool &isDrivingSimulation) {m_isDrivingSimulation=isDrivingSimulation;}
 
+    /// The window may have nothing to display. It should override this method with the corresponding checks.
+    /// For example: the PlottingWindow needs data to plot, if none are given, the window is disabled.
+    virtual bool enabled() {return true;}
+
+    /// This is called before loading / reloading a simulation.
+    virtual void clearWindow() {}
+
     /// Does the window have tools to drive the robot in simulation.
     bool isDrivingSimulation() {return m_isDrivingSimulation;}
 
@@ -47,11 +54,7 @@ class SOFAIMGUI_API BaseWindow
     void setOpen(const bool &isOpen) {m_isOpen=isOpen;}
 
     /// Does the user choose to open the window or not.
-    bool& isOpen() {return m_isOpen;}
-
-    /// The window may have nothing to display. It should override this method with the corresponding checks.
-    /// For example: the PlottingWindow needs data to plot, if none are given, the window is disabled.
-    virtual bool enabled() {return true;}
+    bool& isOpen();
 
    protected:
 

--- a/SofaImGui/src/SofaImGui/windows/IOWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/IOWindow.h
@@ -145,6 +145,8 @@ class SOFAIMGUI_API IOWindow : public BaseWindow
 
     void addSubscribableData(const std::string& name, sofa::core::BaseData* data);
 
+    void clearWindow() override {m_IPController=nullptr;}
+
    protected:
     
     models::IPController::SPtr m_IPController;

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
@@ -39,6 +39,12 @@ MoveWindow::MoveWindow(const std::string& name,
     m_isDrivingSimulation = true;
 }
 
+void MoveWindow::clearWindow()
+{
+    m_IPController = nullptr;
+    m_accessories.clear();
+    m_actuators.clear();
+}
 
 void MoveWindow::setTCPDescriptions(const std::string &positionDescription, const std::string &rotationDescription)
 {

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.h
@@ -52,7 +52,8 @@ class SOFAIMGUI_API MoveWindow : public BaseWindow
         float max{500};
     };
 
-    void clearData() {m_accessories.clear();}
+    void clearWindow() override;
+
     void addAccessory(const Accessory &accessory) {m_accessories.push_back(accessory);}
     bool hasActuators() {return !m_actuators.empty();}
     bool enabled() override {return m_IPController!=nullptr || !m_actuators.empty();}

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
@@ -41,7 +41,7 @@ MyRobotWindow::MyRobotWindow(const std::string& name,
     m_isDrivingSimulation = true;
 }
 
-void MyRobotWindow::clearData()
+void MyRobotWindow::clearWindow()
 {
     m_informationGroups.clear();
     m_settingGroups.clear();

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.h
@@ -60,7 +60,7 @@ class SOFAIMGUI_API MyRobotWindow : public BaseWindow
         std::vector<Setting> settings;
     };
 
-    void clearData();
+    void clearWindow() override;
     void addInformation(const Information &info, const std::string &group);
     void addSetting(const Setting &setting, const std::string &group);
 

--- a/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
@@ -85,9 +85,12 @@ void PlottingWindow::showWindow(sofa::simulation::Node::SPtr groot, const ImGuiW
 {
     SOFA_UNUSED(windowFlags);
 
-    if(!m_data.empty() && m_data.size() == m_buffers.size() && groot->getAnimate())
+    size_t nbData = m_data.size();
+    if (m_buffers.size() != nbData)
+        m_buffers.resize(nbData);
+
+    if(!m_data.empty() && groot->getAnimate())
     {
-        size_t nbData = m_data.size();
         for (size_t k=0; k<nbData; k++)
         {
             auto& data = m_data[k];
@@ -108,14 +111,10 @@ void PlottingWindow::showWindow(sofa::simulation::Node::SPtr groot, const ImGuiW
             auto positionRight = ImGui::GetCursorPosX() + ImGui::GetWindowSize().x - buttonSize.x * 3 - ImGui::GetStyle().ItemSpacing.y * 4; // Get position for right buttons
             auto positionMiddle = ImGui::GetCursorPosX() + ImGui::GetWindowSize().x / 2.f; // Get position for middle button
 
-            size_t nbData = m_data.size();
-            if (m_buffers.size() != nbData)
-                m_buffers.resize(nbData);
-
             if (ImGui::Button("Clear"))
             {
                 for(auto& buffer: m_buffers)
-                    buffer.data.clear();
+                    buffer.clear();
             }
 
             ImGui::SameLine();

--- a/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
@@ -41,7 +41,7 @@ PlottingWindow::PlottingWindow(const std::string& name,
     m_isOpen = isWindowOpen;
 }
 
-void PlottingWindow::clearData()
+void PlottingWindow::clearWindow()
 {
     m_data.clear();
     m_buffers.clear();
@@ -85,7 +85,7 @@ void PlottingWindow::showWindow(sofa::simulation::Node::SPtr groot, const ImGuiW
 {
     SOFA_UNUSED(windowFlags);
 
-    if(!m_data.empty() && groot->getAnimate())
+    if(!m_data.empty() && m_data.size() == m_buffers.size() && groot->getAnimate())
     {
         size_t nbData = m_data.size();
         for (size_t k=0; k<nbData; k++)
@@ -109,7 +109,7 @@ void PlottingWindow::showWindow(sofa::simulation::Node::SPtr groot, const ImGuiW
             auto positionMiddle = ImGui::GetCursorPosX() + ImGui::GetWindowSize().x / 2.f; // Get position for middle button
 
             size_t nbData = m_data.size();
-            if (m_buffers.empty())
+            if (m_buffers.size() != nbData)
                 m_buffers.resize(nbData);
 
             if (ImGui::Button("Clear"))
@@ -272,7 +272,7 @@ void PlottingWindow::showMenu()
         ImGui::PushItemWidth(ImGui::CalcTextSize("-100000,00").x);
         if (ImGui::InputFloat("##Ratio", &ratio, 0, 0, "%0.2e"))
         {
-            size_t nbData = m_data.size();
+            size_t nbData = m_buffers.size();
             for (size_t i=0; i<nbData; i++)
             {
                 auto& buffer = m_buffers[i];

--- a/SofaImGui/src/SofaImGui/windows/PlottingWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/PlottingWindow.h
@@ -36,20 +36,31 @@ class SOFAIMGUI_API PlottingWindow : public BaseWindow
 
     struct RollingBuffer
     {
-        float span;
-        float ratio = 1;
+        float span = 20.f;
+        float xStart = 0.f;
+        float ratio = 1.f;
         ImVector<ImVec2> data;
         RollingBuffer()
         {
-            span = 20.0f;
-            data.reserve(2000);
+            clear();
         }
         void addPoint(float x, float y)
         {
-            float xmod = fmodf(x, span);
-            if (!data.empty() && xmod < data.back().x)
+            float xmod = fmodf(x - xStart, span);
+            if (!data.empty() && xmod < data.back().x - xStart)
+            {
+                xStart = data.front().x;
                 data.erase(data.begin());
+            }
             data.push_back(ImVec2(x, y * ratio));
+        }
+        void clear()
+        {
+            if (!data.empty())
+                xStart = data.front().x;
+
+            data.clear();
+            data.reserve(2000);
         }
     };
 

--- a/SofaImGui/src/SofaImGui/windows/PlottingWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/PlottingWindow.h
@@ -66,7 +66,7 @@ class SOFAIMGUI_API PlottingWindow : public BaseWindow
     void showWindow(sofa::simulation::Node::SPtr groot, const ImGuiWindowFlags &windowFlags);
     bool enabled() override {return !m_data.empty();}
     void addData(const PlottingData data) {m_data.push_back(data);}
-    void clearData();
+    void clearWindow() override;
 
    protected:
     std::vector<PlottingData> m_data;

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
@@ -994,27 +994,13 @@ void ProgramWindow::animateEndEvent(sofa::simulation::Node *groot)
 void ProgramWindow::setIPController(models::IPController::SPtr IPController)
 {
     m_IPController = IPController;
-    m_program = models::Program(IPController);
+    if (m_IPController)
+        m_program = models::Program(IPController);
 }
 
 void ProgramWindow::setDrivingTCPTarget(const bool &isDrivingSimulation)
 {
     m_isDrivingSimulation=isDrivingSimulation;
-}
-
-void ProgramWindow::addTrajectoryComponents(sofa::simulation::Node* groot)
-{
-    const auto& tracks = m_program.getTracks();
-    for (const auto& track: tracks)
-    {
-        const auto& actions = track->getActions();
-        for (const auto& action: actions)
-        {
-            std::shared_ptr<models::actions::Move> move = std::dynamic_pointer_cast<models::actions::Move>(action);
-            if(move)
-                move->addTrajectoryComponent(groot);
-        }
-    }
 }
 
 } // namespace

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.h
@@ -48,6 +48,7 @@ class SOFAIMGUI_API ProgramWindow : public BaseWindow
     void showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI,
                     const ImGuiWindowFlags &windowFlags);
     bool enabled() override {return m_IPController!=nullptr;}
+    void clearWindow() override {m_IPController=nullptr;}
 
     void animateBeginEvent(sofa::simulation::Node *groot);
     void animateEndEvent(sofa::simulation::Node *groot);
@@ -58,8 +59,6 @@ class SOFAIMGUI_API ProgramWindow : public BaseWindow
 
     void importProgram();
     void exportProgram(const bool &exportAs = true);
-
-    void addTrajectoryComponents(sofa::simulation::Node* groot); /// Add to the simulation graph components to draw the trajectory in the 3D view.
 
    protected:
     


### PR DESCRIPTION
**Current Implementation**

Loading a new simulation does not work. Only reloading the simulation works.

**In this PR**

- Restores: open a new simulation
- Forget stored python arguments once the user has loaded a new simulation from the GUI
- Adds `clearWindow()` to `BaseWindow` and generalizes its use
- `BaseWindow::isOpen()`: set `m_isOpen` to false if `enable()` returns false. Useful but questionable?  
- Removes unnecessary `addTrajectoryComponents()`
