### PR TITLE
[ImGuiGUIEngine] Adds Project file

### DIFF
--- a/SofaImGui/src/SofaImGui/AppIniFile.cpp
+++ b/SofaImGui/src/SofaImGui/AppIniFile.cpp
@@ -19,6 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
+#include <filesystem>
+
 #include <SofaImGui/ImGuiGUIEngine.h>
 #include <sofa/helper/Utils.h>
 #include <SofaImGui/AppIniFile.h>
@@ -41,7 +43,10 @@ namespace sofaimgui
 
     const std::string AppIniFile::getProjectFile(std::string sceneFilename)
     {
-        return sceneFilename + ".crproj";
+        std::filesystem::path path(sceneFilename);
+        path = path.replace_extension(".crproj");
+        std::string projectFilename(path.string());
+        return projectFilename;
     }
 
 

--- a/SofaImGui/src/SofaImGui/AppIniFile.cpp
+++ b/SofaImGui/src/SofaImGui/AppIniFile.cpp
@@ -39,6 +39,12 @@ namespace sofaimgui
         return settingsIniFile;
     }
 
+    const std::string AppIniFile::getProjectFile(std::string sceneFilename)
+    {
+        return sceneFilename + ".crproj";
+    }
+
+
     std::string AppIniFile::getIniFile(const std::string filename)
     {
         std::string appIniFile(sofa::helper::Utils::getSofaUserLocalDirectory() + "/" + filename);

--- a/SofaImGui/src/SofaImGui/AppIniFile.h
+++ b/SofaImGui/src/SofaImGui/AppIniFile.h
@@ -32,6 +32,7 @@ namespace sofaimgui
     public:
         static const std::string& getWindowsIniFile();
         static const std::string& getSettingsIniFile();
+        static const std:: string getProjectFile(std::string sceneFilename);
 
     private:
         static std::string getIniFile(const std::string filename);

--- a/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
+++ b/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
@@ -110,8 +110,8 @@ void FooterStatusBar::showTempMessageOnStatusBar()
 
                 ImGui::EndMenuBar();
             }
-            ImGui::End();
         }
+        ImGui::End();
     }
 }
 

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -106,7 +106,7 @@ namespace sofaimgui
 void ImGuiGUIEngine::saveSettings()
 {
     const std::string settingsFile = sofaimgui::AppIniFile::getSettingsIniFile();
-    msg_info("") << "Saving application settings in " << settingsFile;
+    FooterStatusBar::getInstance().setTempMessage("Saving application settings in " + settingsFile);
 
     ImGuiViewport* viewport = ImGui::GetMainViewport();
     iniGUISettings.SetDoubleValue("Window", "width", viewport->Size.x);
@@ -118,7 +118,7 @@ void ImGuiGUIEngine::saveSettings()
 void ImGuiGUIEngine::saveProject()
 {
     const std::string projectFile = sofaimgui::AppIniFile::getProjectFile(m_sceneFilename);
-    msg_info("") << "Saving project in " << projectFile;
+    FooterStatusBar::getInstance().setTempMessage("Saving project in " + projectFile);
 
     // Save windows settings in project file
     for (const auto& window : m_windows)
@@ -739,6 +739,13 @@ void ImGuiGUIEngine::key_callback(GLFWwindow* window, int key, int scancode, int
             if (action == GLFW_PRESS && isCtrlKeyPressed && isShiftKeyPressed)
             {
                 m_programWindow.exportProgram(false);
+            }
+        }
+        else if (strcmp(keyName, "s") == 0)
+        {
+            if (action == GLFW_PRESS && isCtrlKeyPressed)
+            {
+                saveProject();
             }
         }
     }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -777,20 +777,21 @@ void ImGuiGUIEngine::loadSimulation(const bool& reload, const std::string& filen
     m_stateWindow->setSimulationState(m_simulationState);
     m_sceneFilename = filename;
 
-    if (sofa::helper::system::FileSystem::exists(sofaimgui::AppIniFile::getProjectFile(m_baseGUI->getFilename())))
+    // Set enable the right windows basesd on file
+    for (const auto& window : m_windows)
     {
-        SI_Error rc = iniProject.LoadFile(sofaimgui::AppIniFile::getProjectFile(m_baseGUI->getFilename()).c_str());
-        SOFA_UNUSED(rc);
-        assert(rc == SI_OK);
+        window.get().setOpen(window.get().getDefaultIsOpen());
 
-        // Set enable the right windows basesd on file
-        for (const auto& window : m_windows)
+        if (sofa::helper::system::FileSystem::exists(sofaimgui::AppIniFile::getProjectFile(m_baseGUI->getFilename())))
         {
-            std::string name = "Window." + window.get().getName();
-            if (iniProject.KeyExists(name.c_str(), "open"))
-                window.get().setOpen(iniProject.GetBoolValue(name.c_str(), "open"));
-        }
+            SI_Error rc = iniProject.LoadFile(sofaimgui::AppIniFile::getProjectFile(m_baseGUI->getFilename()).c_str());
+            SOFA_UNUSED(rc);
+            assert(rc == SI_OK);
 
+                std::string name = "Window." + window.get().getName();
+                if (iniProject.KeyExists(name.c_str(), "open"))
+                    window.get().setOpen(iniProject.GetBoolValue(name.c_str(), "open"));
+        }
     }
     initDockSpace(true);
 }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -107,13 +107,16 @@ protected:
     std::unique_ptr<sofa::gl::FrameBufferObject> m_fbo;
     std::pair<unsigned int, unsigned int> m_currentFBOSize;
 
-    std::vector<std::reference_wrapper<windows::BaseWindow>> m_windows{ m_viewportWindow, 
-                                                                        m_sceneGraphWindow, 
-                                                                        m_logWindow, m_IOWindow, 
-                                                                        m_programWindow, 
-                                                                        m_plottingWindow, 
-                                                                        m_myRobotWindow, 
-                                                                        m_moveWindow};
+    std::vector<std::reference_wrapper<windows::BaseWindow>> m_windows{
+                                                                        m_IOWindow,
+                                                                        m_programWindow,
+                                                                        m_myRobotWindow,
+                                                                        m_moveWindow,
+                                                                        m_plottingWindow,
+                                                                        m_viewportWindow,
+                                                                        m_sceneGraphWindow,
+                                                                        m_logWindow,
+    };
 
     CSimpleIniA iniGUISettings;
     CSimpleIniA iniProject;

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -79,6 +79,8 @@ public:
 
     void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods) override;
 
+    void saveProject();
+
     void setIPController(sofa::simulation::Node::SPtr groot,
                          softrobotsinverse::solver::QPInverseProblemSolver::SPtr solver,
                          sofa::core::behavior::BaseMechanicalState::SPtr TCPTargetMechanical,
@@ -130,7 +132,6 @@ protected:
     void applyDarkMode(const bool &darkMode, sofaglfw::SofaGLFWBaseGUI* baseGUI=nullptr);
 
     void saveSettings();
-    void saveProject();
     void loadSimulation(const bool& reload, const std::string &filename);
     void clearGUI();
     void setDockSizeFromFile(const ImGuiID& id);

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -130,6 +130,7 @@ protected:
     void saveProject();
     void loadSimulation(const bool& reload, const std::string &filename);
     void clearGUI();
+    void setDockSizeFromFile(const ImGuiID& id);
 
     models::IPController::SPtr m_IPController;
     models::SimulationState m_simulationState;
@@ -137,6 +138,7 @@ protected:
     int m_mode{0};
     bool m_darkMode{false};
     sofaglfw::SofaGLFWBaseGUI* m_baseGUI{nullptr};
+    std::vector<ImGuiID> m_dockIDs;
 };
 
 } // namespace sofaimgui

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -102,11 +102,21 @@ public:
     windows::MoveWindow         m_moveWindow         = windows::MoveWindow("       Move", true);
 
 
+
 protected:
     std::unique_ptr<sofa::gl::FrameBufferObject> m_fbo;
     std::pair<unsigned int, unsigned int> m_currentFBOSize;
 
-    CSimpleIniA ini;
+    std::vector<std::reference_wrapper<windows::BaseWindow>> m_windows{ m_viewportWindow, 
+                                                                        m_sceneGraphWindow, 
+                                                                        m_logWindow, m_IOWindow, 
+                                                                        m_programWindow, 
+                                                                        m_plottingWindow, 
+                                                                        m_myRobotWindow, 
+                                                                        m_moveWindow};
+
+    CSimpleIniA iniGUISettings;
+    CSimpleIniA iniProject;
 
     void showFrameOnViewport(sofaglfw::SofaGLFWBaseGUI *baseGUI);
     void initDockSpace();
@@ -117,6 +127,7 @@ protected:
     void applyDarkMode(const bool &darkMode, sofaglfw::SofaGLFWBaseGUI* baseGUI=nullptr);
 
     void saveSettings();
+    void saveProject();
     void loadSimulation(const bool& reload, const std::string &filename);
     void clearGUI();
 

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -119,7 +119,7 @@ protected:
     CSimpleIniA iniProject;
 
     void showFrameOnViewport(sofaglfw::SofaGLFWBaseGUI *baseGUI);
-    void initDockSpace();
+    void initDockSpace(const bool& firstTime);
     void showViewportWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI);
     void showOptionWindows(sofaglfw::SofaGLFWBaseGUI* baseGUI);
     void showMainMenuBar(sofaglfw::SofaGLFWBaseGUI* baseGUI);
@@ -139,6 +139,7 @@ protected:
     bool m_darkMode{false};
     sofaglfw::SofaGLFWBaseGUI* m_baseGUI{nullptr};
     std::vector<ImGuiID> m_dockIDs;
+    std::string m_sceneFilename;
 };
 
 } // namespace sofaimgui

--- a/SofaImGui/src/SofaImGui/menus/FileMenu.cpp
+++ b/SofaImGui/src/SofaImGui/menus/FileMenu.cpp
@@ -158,6 +158,11 @@ bool FileMenu::addImportExportProgram()
     if (!engine)
         return false;
 
+    if (ImGui::MenuItem("Save Project", "Ctrl+S"))
+    {
+        engine->saveProject();
+    }
+
     if (!engine->m_programWindow.enabled())
         ImGui::BeginDisabled();
 

--- a/SofaImGui/src/SofaImGui/windows/BaseWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/BaseWindow.h
@@ -56,11 +56,15 @@ class SOFAIMGUI_API BaseWindow
     /// Does the user choose to open the window or not.
     bool& isOpen();
 
+    /// 
+    const bool& getDefaultIsOpen() { return m_defaultIsOpen; }
+
    protected:
 
     bool m_isOpen{false}; /// The user choice to open the window or not
     std::string m_name = "Window"; /// The name of the window
     bool m_isDrivingSimulation{false}; /// Does the window have tools to drive the robot in simulation
+    bool m_defaultIsOpen{false}; // The default open state when there is no project file
 };
 
 }

--- a/SofaImGui/src/SofaImGui/windows/IOWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/IOWindow.cpp
@@ -40,6 +40,8 @@ namespace sofaimgui::windows {
 
 IOWindow::IOWindow(const std::string& name, const bool& isWindowOpen)
 {
+
+    m_defaultIsOpen = false;
     m_name = name;
     m_isOpen = isWindowOpen;
 

--- a/SofaImGui/src/SofaImGui/windows/LogWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/LogWindow.cpp
@@ -44,6 +44,7 @@ namespace sofaimgui::windows {
 
 LogWindow::LogWindow(const std::string& name, const bool& isWindowOpen)
 {
+    m_defaultIsOpen = false;
     m_name = name;
     m_isOpen = isWindowOpen;
     m_isDrivingSimulation = false;

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
@@ -34,6 +34,7 @@ namespace sofaimgui::windows {
 MoveWindow::MoveWindow(const std::string& name,
                          const bool& isWindowOpen)
 {
+    m_defaultIsOpen = true;
     m_name = name;
     m_isOpen = isWindowOpen;
     m_isDrivingSimulation = true;

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
@@ -38,6 +38,7 @@ std::string MyRobotWindow::DEFAULTGROUP = "empty";
 MyRobotWindow::MyRobotWindow(const std::string& name,
                          const bool& isWindowOpen)
 {
+    m_defaultIsOpen = true;
     m_name = name;
     m_isOpen = isWindowOpen;
     m_isDrivingSimulation = true;

--- a/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
@@ -37,6 +37,7 @@ namespace sofaimgui::windows {
 PlottingWindow::PlottingWindow(const std::string& name,
                                const bool& isWindowOpen)
 {
+    m_defaultIsOpen = true;
     m_name = name;
     m_isOpen = isWindowOpen;
 }

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
@@ -52,6 +52,7 @@ using sofa::type::Quat;
 ProgramWindow::ProgramWindow(const std::string& name,
                              const bool& isWindowOpen)
 {
+    m_defaultIsOpen = true;
     m_name = name;
     m_isOpen = isWindowOpen;
 }

--- a/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
@@ -30,6 +30,7 @@ namespace sofaimgui::windows {
 
 SceneGraphWindow::SceneGraphWindow(const std::string& name, const bool& isWindowOpen)
 {
+    m_defaultIsOpen = false;
     m_name = name;
     m_isOpen = isWindowOpen;
 }

--- a/SofaImGui/src/SofaImGui/windows/StateWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/StateWindow.cpp
@@ -98,8 +98,8 @@ void StateWindow::showWindow()
                     ImGui::EndTable();
                 }
             }
-            ImGui::End();
         }
+        ImGui::End();
         ImGui::PopStyleColor();
     }
 }

--- a/SofaImGui/src/SofaImGui/windows/StateWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/StateWindow.cpp
@@ -30,6 +30,7 @@ namespace sofaimgui::windows {
 StateWindow::StateWindow(const std::string& name,
                          const bool& isWindowOpen)
 {
+    m_defaultIsOpen = false;
     m_name = name;
     m_isOpen = isWindowOpen;
 }

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -118,14 +118,14 @@ bool ViewportWindow::addStepButton()
                         isItemClicked = true;
                     ImGui::PopItemFlag();
                     ImGui::SetItemTooltip("One step of simulation");
-                    ImGui::End();
                 }
+                ImGui::End();
                 ImGui::PopStyleColor();
 
                 ImGui::EndChild();
             }
-            ImGui::End();
         }
+        ImGui::End();
     }
 
     return isItemClicked;
@@ -161,14 +161,14 @@ bool ViewportWindow::addAnimateButton(bool *animate)
                         isItemClicked = true;
                     }
 
-                    ImGui::End();
                 }
+                ImGui::End();
                 ImGui::PopStyleColor();
 
                 ImGui::EndChild();
             }
-            ImGui::End();
         }
+        ImGui::End();
     }
 
     return isItemClicked;
@@ -203,14 +203,14 @@ bool ViewportWindow::addDrivingTabCombo(int *mode, const char *listModes[], cons
                     ImGui::PopItemWidth();
                     ImGui::SetItemTooltip("Choose a window to drive the TCP target");
 
-                    ImGui::End();
                 }
+                ImGui::End();
                 ImGui::PopStyleColor();
 
                 ImGui::EndChild();
             }
-            ImGui::End();
         }
+        ImGui::End();
     }
 
     return hasValueChanged;

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -29,6 +29,7 @@ namespace sofaimgui::windows {
 ViewportWindow::ViewportWindow(const std::string& name, const bool& isWindowOpen, std::shared_ptr<StateWindow> stateWindow)
     : m_stateWindow(stateWindow)
 {
+    m_defaultIsOpen = true;
     m_name = name;
     m_isOpen = isWindowOpen;
 }


### PR DESCRIPTION
Implements #61. Adds a project file with the same name as the scene with the extension `crproj`.

For now, it only saves which windows were opened and which were closed when the user closed the app.

Notable changes: 
- it adds a vector of references to the windows to be able to loop over them. Thank to this, refactor has been made
- Another instance of CSimpleIni has been added to `ImGuiGUIEngine` to manage these new parameters
- the title of windows (not docked) is now centered


- [x] fix name of cproj file: now it is ` path/to/scenefile.py.crproj` instead of ` path/to/scenefile.crproj`
- [x] when loading new scene from the app, load the associated project file