### PR TITLE
[View] Switch to orthographic mode when aligning the camera

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -94,7 +94,6 @@ void SofaGLFWWindow::draw(sofa::simulation::NodeSPtr groot, sofa::core::visual::
     vparams->setModelViewMatrix(mvMatrix);
 
     sofa::simulation::node::draw(vparams, groot.get());
-
 }
 
 void SofaGLFWWindow::setBackgroundColor(const sofa::type::RGBAColor& newColor)
@@ -148,6 +147,13 @@ void SofaGLFWWindow::mouseMoveEvent(int xpos, int ypos)
         m_currentCamera->manageEvent(mEvent);
         m_currentXPos = xpos;
         m_currentYPos = ypos;
+
+        // If we rotate the view, we should use the perspective mode
+        if(m_currentCamera->d_activated.getValue())
+            if (sofa::core::objectmodel::MouseEvent::checkEventType(mEvent))
+                if(mEvent->getState() == sofa::core::objectmodel::MouseEvent::LeftPressed)
+                    m_currentCamera->setCameraType(sofa::core::visual::VisualParams::PERSPECTIVE_TYPE);
+
         break;
     }
     case GLFW_RELEASE:

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -150,9 +150,8 @@ void SofaGLFWWindow::mouseMoveEvent(int xpos, int ypos)
 
         // If we rotate the view, we should use the perspective mode
         if(m_currentCamera->d_activated.getValue())
-            if (sofa::core::objectmodel::MouseEvent::checkEventType(mEvent))
-                if(mEvent->getState() == sofa::core::objectmodel::MouseEvent::LeftPressed)
-                    m_currentCamera->setCameraType(sofa::core::visual::VisualParams::PERSPECTIVE_TYPE);
+            if(mEvent->getState() == sofa::core::objectmodel::MouseEvent::LeftPressed)
+                m_currentCamera->setCameraType(sofa::core::visual::VisualParams::PERSPECTIVE_TYPE);
 
         break;
     }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -709,7 +709,7 @@ void ImGuiGUIEngine::key_callback(GLFWwindow* window, int key, int scancode, int
         }
     }
 
-    if(m_viewportWindow.isFocusOnViewport())
+    if(m_viewportWindow.isFocusOnViewport() && action==GLFW_PRESS)
     {
         switch (key)
         {

--- a/SofaImGui/src/SofaImGui/Utils.cpp
+++ b/SofaImGui/src/SofaImGui/Utils.cpp
@@ -20,6 +20,7 @@
  * Contact information: contact@sofa-framework.org                             *
  ******************************************************************************/
 
+#include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/system/FileSystem.h>
 #include <SofaImGui/Utils.h>
 #include <sofa/core/behavior/BaseMechanicalState.h>
@@ -125,6 +126,7 @@ void alignCamera(sofaglfw::SofaGLFWBaseGUI *baseGUI, const CameraAlignement& ali
         auto distance = *std::max_element(box.begin(), box.end());
         const auto& position = camera->getPositionFromOrientation(sofa::type::Vec3(0., 0., 0.), -distance*2.f, orientation);
         camera->setView(position + bbCenter, orientation);
+        camera->setCameraType(sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE);
     }
 }
 } // namespace

--- a/SofaImGui/src/SofaImGui/Utils.cpp
+++ b/SofaImGui/src/SofaImGui/Utils.cpp
@@ -122,9 +122,9 @@ void alignCamera(sofaglfw::SofaGLFWBaseGUI *baseGUI, const CameraAlignement& ali
         }
 
         auto bbCenter = (groot->f_bbox.getValue().maxBBox() + groot->f_bbox.getValue().minBBox()) * 0.5f;
-        auto lookAtPosition = sofa::type::Vec3(0., 0., 0.);
-        const auto& cameraPosition = camera->getPositionFromOrientation(lookAtPosition, -camera->getDistance(), orientation);
+        const auto& cameraPosition = camera->getPositionFromOrientation(sofa::type::Vec3(0., 0., 0.), -camera->getDistance(), orientation);
         camera->setView(cameraPosition + bbCenter, orientation);
+        camera->d_lookAt.setValue(bbCenter);
         camera->setCameraType(sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE);
     }
 }

--- a/SofaImGui/src/SofaImGui/Utils.cpp
+++ b/SofaImGui/src/SofaImGui/Utils.cpp
@@ -121,11 +121,10 @@ void alignCamera(sofaglfw::SofaGLFWBaseGUI *baseGUI, const CameraAlignement& ali
             break;
         }
 
-        auto box = groot->f_bbox.getValue().maxBBox() - groot->f_bbox.getValue().minBBox();
         auto bbCenter = (groot->f_bbox.getValue().maxBBox() + groot->f_bbox.getValue().minBBox()) * 0.5f;
-        auto distance = *std::max_element(box.begin(), box.end());
-        const auto& position = camera->getPositionFromOrientation(sofa::type::Vec3(0., 0., 0.), -distance*2.f, orientation);
-        camera->setView(position + bbCenter, orientation);
+        auto lookAtPosition = sofa::type::Vec3(0., 0., 0.);
+        const auto& cameraPosition = camera->getPositionFromOrientation(lookAtPosition, -camera->getDistance(), orientation);
+        camera->setView(cameraPosition + bbCenter, orientation);
         camera->setCameraType(sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE);
     }
 }

--- a/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
+++ b/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
@@ -183,16 +183,16 @@ void ViewMenu::addViewport()
         {
             static bool show01 = false;
             if (ImGui::LocalCheckBox("Square size: 0.1", &show01))
-                showGrid(show01, 0.1f, 1.f);
+                showGrid(show01, 0.1f, 0.5f);
             static bool show1 = false;
             if (ImGui::LocalCheckBox("Square size: 1", &show1))
-                showGrid(show1, 1.f, 1.f);
+                showGrid(show1, 1.f, 0.5f);
             static bool show10 = false;
             if (ImGui::LocalCheckBox("Square size: 10", &show10))
-                showGrid(show10, 10.f, 2.f);
+                showGrid(show10, 10.f, 1.f);
             static bool show100 = false;
             if (ImGui::LocalCheckBox("Square size: 100", &show100))
-                showGrid(show100, 100.f, 3.f);
+                showGrid(show100, 100.f, 2.f);
 
             ImGui::EndMenu();
         }


### PR DESCRIPTION
The view switches to the orthographic mode when we align the camera.
Rotating the view with the mouse makes the camera mode switch back to perspective.

<img width="3840" height="2229" alt="image" src="https://github.com/user-attachments/assets/0a632837-d473-4d67-aab6-8f3df71ca959" />
<img width="3840" height="2229" alt="image" src="https://github.com/user-attachments/assets/aaffdd41-2912-4964-93c9-ca378680964b" />
