### PR TITLE
[ViewMenu] align grid when aligning camera

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,17 @@ jobs:
           sofa_scope: 'standard'     
           pybind11_version: "${{ runner.os == 'Windows' && '2.9.1' || '2.12.0' }}"
 
+      - name: Switch to gcc-13 on Ubuntu
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt install software-properties-common
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            sudo apt update
+            sudo apt install gcc-13 g++-13
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
+          fi
+
       - name: Install SoftRobots
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,14 @@ jobs:
           sofa_scope: 'standard'
           
       - name: Switch to gcc-13 on Ubuntu
+        shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt install software-properties-common
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            sudo apt update
             sudo apt install gcc-13 g++-13
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
           fi
 
       - name: Checkout source code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
           sofa_version: ${{ matrix.sofa_branch }}
           sofa_scope: 'standard'
           
-      - name: Switch to gcc-10 on Ubuntu
+      - name: Switch to gcc-13 on Ubuntu
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo apt install gcc-10 g++-10
+            sudo apt install gcc-13 g++-13
           fi
 
       - name: Checkout source code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
           sofa_scope: 'standard'
           
       - name: Switch to gcc-10 on Ubuntu
-        if: matrix.configurations.os == "ubuntu-22.04"
         run: |
-          sudo apt install gcc-10 g++-10
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt install gcc-10 g++-10
+          fi
 
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-14, windows-2022]
         sofa_branch: [master]
-
+        
     steps:
       - name: Setup SOFA and environment
         id: sofa
@@ -28,7 +28,12 @@ jobs:
           sofa_root: ${{ github.workspace }}/sofa
           sofa_version: ${{ matrix.sofa_branch }}
           sofa_scope: 'standard'
-      
+          
+      - name: Switch to gcc-10 on Ubuntu
+        if: matrix.configurations.os == "ubuntu-22.04"
+        run: |
+          sudo apt install gcc-10 g++-10
+
       - name: Checkout source code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,6 @@ jobs:
           sofa_root: ${{ github.workspace }}/sofa
           sofa_version: ${{ matrix.sofa_branch }}
           sofa_scope: 'standard'
-          
-      - name: Switch to gcc-13 on Ubuntu
-        shell: bash
-        run: |
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo apt install software-properties-common
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-            sudo apt update
-            sudo apt install gcc-13 g++-13
-            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
-          fi
 
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -184,17 +173,6 @@ jobs:
           sofa_version: ${{ matrix.sofa_branch }}
           sofa_scope: 'standard'     
           pybind11_version: "${{ runner.os == 'Windows' && '2.9.1' || '2.12.0' }}"
-
-      - name: Switch to gcc-13 on Ubuntu
-        shell: bash
-        run: |
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo apt install software-properties-common
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-            sudo apt update
-            sudo apt install gcc-13 g++-13
-            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13
-          fi
 
       - name: Install SoftRobots
         shell: bash

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -612,7 +612,7 @@ void SofaGLFWBaseGUI::cursor_position_callback(GLFWwindow* window, double xpos, 
         auto currentSofaWindow = s_mapWindows.find(window);
         if (currentSofaWindow != s_mapWindows.end() && currentSofaWindow->second)
         {
-            currentSofaWindow->second->mouseMoveEvent(static_cast<int>(xpos), static_cast<int>(ypos));
+            currentSofaWindow->second->mouseMoveEvent(currentGUI->second->getRootNode(), static_cast<int>(xpos), static_cast<int>(ypos));
         }
     }
 }

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -26,6 +26,7 @@
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/objectmodel/MouseEvent.h>
+#include <sofa/helper/system/FileSystem.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/gl/gl.h>
@@ -33,6 +34,11 @@
 
 namespace sofaglfw
 {
+
+float SofaGLFWWindow::GridSquareSize::METER = 0.1;
+float SofaGLFWWindow::GridSquareSize::DECIMETER = 1;
+float SofaGLFWWindow::GridSquareSize::CENTIMETER = 10;
+float SofaGLFWWindow::GridSquareSize::MILLIMETER = 100;
 
 SofaGLFWWindow::SofaGLFWWindow(GLFWwindow* glfwWindow, sofa::component::visual::BaseCamera::SPtr camera)
     : m_glfwWindow(glfwWindow)
@@ -127,7 +133,94 @@ void SofaGLFWWindow::centerCamera(sofa::simulation::NodeSPtr node, sofa::core::v
     }
 }
 
-void SofaGLFWWindow::mouseMoveEvent(int xpos, int ypos)
+
+void SofaGLFWWindow::resetSimulationView(sofaglfw::SofaGLFWBaseGUI *baseGUI)
+{
+    if (baseGUI)
+    {
+        sofa::core::sptr<sofa::simulation::Node> groot = baseGUI->getRootNode();
+        const std::string viewFileName = baseGUI->getFilename() + ".view";
+        bool fileExists = sofa::helper::system::FileSystem::exists(viewFileName);
+        sofa::component::visual::BaseCamera::SPtr camera;
+        if (groot)
+        {
+            groot->get(camera);
+            if (camera && fileExists)
+            {
+                if (camera->importParametersFromFile(viewFileName))
+                {
+                    msg_info("GUI") << "Current camera parameters have been imported from " << viewFileName << ".";
+                }
+                else
+                {
+                    msg_error("GUI") << "Could not import camera parameters from " << viewFileName << ".";
+                }
+            }
+        }
+    }
+}
+
+
+void SofaGLFWWindow::alignCamera(sofa::simulation::NodeSPtr groot, const CameraAlignement& align)
+{
+    sofa::component::visual::BaseCamera::SPtr camera;
+    groot->get(camera);
+
+    if (camera)
+    {
+        sofa::type::Quat<float> orientation;
+
+        switch(align)
+        {
+        case TOP:
+            orientation = sofa::type::Quat(-0.707, 0., 0., 0.707);
+            setGridsPlane(groot);
+            break;
+        case BOTTOM:
+            orientation = sofa::type::Quat(0.707, 0., 0., 0.707);
+            setGridsPlane(groot);
+            break;
+        case FRONT:
+            orientation = sofa::type::Quat(0., 0., 0., 1.);
+            setGridsPlane(groot, VisualGrid::PlaneType("z"));
+            break;
+        case BACK:
+            orientation = sofa::type::Quat(0., 1., 0., 0.);
+            setGridsPlane(groot, VisualGrid::PlaneType("z"));
+            break;
+        case LEFT:
+            orientation = sofa::type::Quat(0., 0.707, 0., 0.707);
+            setGridsPlane(groot, VisualGrid::PlaneType("x"));
+            break;
+        case RIGHT:
+            orientation = sofa::type::Quat(0., -0.707, 0., 0.707);
+            setGridsPlane(groot, VisualGrid::PlaneType("x"));
+            break;
+        }
+
+        auto bbCenter = (groot->f_bbox.getValue().maxBBox() + groot->f_bbox.getValue().minBBox()) * 0.5f;
+        const auto& cameraPosition = camera->getPositionFromOrientation(sofa::type::Vec3(0., 0., 0.), -camera->getDistance(), orientation);
+        camera->setView(cameraPosition + bbCenter, orientation);
+        camera->d_lookAt.setValue(bbCenter);
+        camera->setCameraType(sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE);
+    }
+}
+
+void SofaGLFWWindow::setGridsPlane(sofa::simulation::NodeSPtr groot, const VisualGrid::PlaneType &plane)
+{
+    if (groot)
+    {
+        auto squareSizes = GridSquareSize::getSquareSizes();
+        for (const auto& squareSize: squareSizes)
+        {
+            auto grid = groot->get<sofa::component::visual::VisualGrid>(std::string("ViewportGrid" + GridSquareSize::getString(squareSize)));
+            if (grid)
+                grid->d_plane.setValue(plane);
+        }
+    }
+}
+
+void SofaGLFWWindow::mouseMoveEvent(sofa::simulation::NodeSPtr groot, int xpos, int ypos)
 {
     switch (m_currentAction)
     {
@@ -150,8 +243,13 @@ void SofaGLFWWindow::mouseMoveEvent(int xpos, int ypos)
 
         // If we rotate the view, we should use the perspective mode
         if(m_currentCamera->d_activated.getValue())
+        {
             if(mEvent->getState() == sofa::core::objectmodel::MouseEvent::LeftPressed)
+            {
                 m_currentCamera->setCameraType(sofa::core::visual::VisualParams::PERSPECTIVE_TYPE);
+                setGridsPlane(groot);
+            }
+        }
 
         break;
     }

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -35,11 +35,6 @@
 namespace sofaglfw
 {
 
-float SofaGLFWWindow::GridSquareSize::METER = 0.1;
-float SofaGLFWWindow::GridSquareSize::DECIMETER = 1;
-float SofaGLFWWindow::GridSquareSize::CENTIMETER = 10;
-float SofaGLFWWindow::GridSquareSize::MILLIMETER = 100;
-
 SofaGLFWWindow::SofaGLFWWindow(GLFWwindow* glfwWindow, sofa::component::visual::BaseCamera::SPtr camera)
     : m_glfwWindow(glfwWindow)
     , m_currentCamera(camera)

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
@@ -20,15 +20,19 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
+#include <SofaGLFW/SofaGLFWBaseGUI.h>
 #include <SofaGLFW/config.h>
 
 #include <sofa/simulation/fwd.h>
 #include <sofa/component/visual/BaseCamera.h>
+#include <sofa/component/visual/VisualGrid.h>
 
 struct GLFWwindow;
 
 namespace sofaglfw
 {
+
+using sofa::component::visual::VisualGrid;
 
 class SOFAGLFW_API SofaGLFWWindow
 {
@@ -39,13 +43,44 @@ public:
     void draw(sofa::simulation::NodeSPtr groot, sofa::core::visual::VisualParams* vparams);
     void close();
 
-    void mouseMoveEvent(int xpos, int ypos);
+    void mouseMoveEvent(sofa::simulation::NodeSPtr groot, int xpos, int ypos);
     void mouseButtonEvent(int button, int action, int mods);
     void scrollEvent(double xoffset, double yoffset);
     void setBackgroundColor(const sofa::type::RGBAColor& newColor);
 
     void setCamera(sofa::component::visual::BaseCamera::SPtr newCamera);
     void centerCamera(sofa::simulation::NodeSPtr node, sofa::core::visual::VisualParams* vparams) const;
+
+    enum CameraAlignement{TOP, BOTTOM, LEFT, RIGHT, FRONT, BACK};
+
+    struct GridSquareSize{
+        static float METER;
+        static float DECIMETER;
+        static float CENTIMETER;
+        static float MILLIMETER;
+
+        static sofa::type::vector<float> getSquareSizes() {return sofa::type::vector{METER, DECIMETER, CENTIMETER, MILLIMETER};}
+        static std::string getString(const float& squareSize)
+        {
+            if (squareSize == METER)
+                return "0.1";
+
+            if (squareSize == DECIMETER)
+                return "1";
+
+            if (squareSize == CENTIMETER)
+                return "10";
+
+            if (squareSize == MILLIMETER)
+                return "100";
+
+            return "";
+        }
+    };
+
+    static void resetSimulationView(sofaglfw::SofaGLFWBaseGUI *baseGUI);
+    static void alignCamera(sofa::simulation::NodeSPtr groot, const CameraAlignement &align);
+    static void setGridsPlane(sofa::simulation::NodeSPtr groot, const VisualGrid::PlaneType &plane = VisualGrid::PlaneType("y"));
 
 private:
     GLFWwindow* m_glfwWindow{nullptr};

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
@@ -54,10 +54,10 @@ public:
     enum CameraAlignement{TOP, BOTTOM, LEFT, RIGHT, FRONT, BACK};
 
     struct GridSquareSize{
-        static float METER;
-        static float DECIMETER;
-        static float CENTIMETER;
-        static float MILLIMETER;
+        constexpr static float METER = 0.1;
+        constexpr static float DECIMETER = 1;
+        constexpr static float CENTIMETER = 10;
+        constexpr static float MILLIMETER = 100;
 
         static sofa::type::vector<float> getSquareSizes() {return sofa::type::vector{METER, DECIMETER, CENTIMETER, MILLIMETER};}
         static std::string getString(const float& squareSize)

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
@@ -20,7 +20,6 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
-#include <format>
 #include <SofaGLFW/SofaGLFWBaseGUI.h>
 #include <SofaGLFW/config.h>
 
@@ -63,9 +62,17 @@ public:
         static sofa::type::vector<float> getSquareSizes() {return sofa::type::vector{METER, DECIMETER, CENTIMETER, MILLIMETER};}
         static std::string getString(const float& squareSize)
         {
-            auto sizes = getSquareSizes();
-            if(std::find(sizes.begin(), sizes.end(), squareSize) != sizes.end())
-               return std::format("{:<3}", squareSize);
+            if (squareSize == METER)
+                return "0.1";
+
+            if (squareSize == DECIMETER)
+                return "1";
+
+            if (squareSize == CENTIMETER)
+                return "10";
+
+            if (squareSize == MILLIMETER)
+                return "100";
 
             return "";
         }

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
@@ -62,17 +62,9 @@ public:
         static sofa::type::vector<float> getSquareSizes() {return sofa::type::vector{METER, DECIMETER, CENTIMETER, MILLIMETER};}
         static std::string getString(const float& squareSize)
         {
-            if (squareSize == METER)
-                return "0.1";
-
-            if (squareSize == DECIMETER)
-                return "1";
-
-            if (squareSize == CENTIMETER)
-                return "10";
-
-            if (squareSize == MILLIMETER)
-                return "100";
+            auto sizes = getSquareSizes();
+            if(std::find(sizes.begin(), sizes.end(), squareSize) != sizes.end())
+               return std::format("{:<3}", squareSize);
 
             return "";
         }

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #pragma once
+#include <format>
 #include <SofaGLFW/SofaGLFWBaseGUI.h>
 #include <SofaGLFW/config.h>
 

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -35,6 +35,7 @@
 #include <SofaImGui/windows/ViewPort.h>
 
 #include <SofaGLFW/SofaGLFWBaseGUI.h>
+#include <SofaGLFW/SofaGLFWWindow.h>
 
 #include <sofa/gl/component/rendering3d/OglSceneFrame.h>
 #include <sofa/gui/common/BaseGUI.h>
@@ -375,7 +376,7 @@ void ImGuiGUIEngine::showViewportWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI)
     if (firstTime)
     {
         firstTime = false;
-        Utils::resetSimulationView(baseGUI);
+        sofaglfw::SofaGLFWWindow::resetSimulationView(baseGUI);
     }
 
     m_viewportWindow.showWindow(groot.get(), (ImTextureID)m_fbo->getColorTexture(),
@@ -711,25 +712,26 @@ void ImGuiGUIEngine::key_callback(GLFWwindow* window, int key, int scancode, int
 
     if(m_viewportWindow.isFocusOnViewport() && action==GLFW_PRESS)
     {
+        const auto& groot = m_baseGUI->getRootNode();
         switch (key)
         {
         case GLFW_KEY_1:
-            sofaimgui::Utils::alignCamera(m_baseGUI, sofaimgui::Utils::CameraAlignement::TOP);
+            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::TOP);
             break;
         case GLFW_KEY_2:
-            sofaimgui::Utils::alignCamera(m_baseGUI, sofaimgui::Utils::CameraAlignement::BOTTOM);
+            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::BOTTOM);
             break;
         case GLFW_KEY_3:
-            sofaimgui::Utils::alignCamera(m_baseGUI, sofaimgui::Utils::CameraAlignement::FRONT);
+            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::FRONT);
             break;
         case GLFW_KEY_4:
-            sofaimgui::Utils::alignCamera(m_baseGUI, sofaimgui::Utils::CameraAlignement::BACK);
+            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::BACK);
             break;
         case GLFW_KEY_5:
-            sofaimgui::Utils::alignCamera(m_baseGUI, sofaimgui::Utils::CameraAlignement::RIGHT);
+            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::RIGHT);
             break;
         case GLFW_KEY_6:
-            sofaimgui::Utils::alignCamera(m_baseGUI, sofaimgui::Utils::CameraAlignement::LEFT);
+            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::LEFT);
             break;
         }
     }

--- a/SofaImGui/src/SofaImGui/Utils.h
+++ b/SofaImGui/src/SofaImGui/Utils.h
@@ -25,12 +25,10 @@
 
 namespace sofaimgui::Utils {
 
-void loadFile(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool &reload, const std::string& filePathName);
-void resetSimulationView(sofaglfw::SofaGLFWBaseGUI *baseGUI);
-void loadSimulation(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool& reload, const std::string& filePathName);
+using namespace sofa::component::visual;
 
-enum CameraAlignement{TOP, BOTTOM, LEFT, RIGHT, FRONT, BACK};
-void alignCamera(sofaglfw::SofaGLFWBaseGUI *baseGUI, const CameraAlignement &align);
+void loadFile(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool &reload, const std::string& filePathName);
+void loadSimulation(sofaglfw::SofaGLFWBaseGUI *baseGUI, const bool& reload, const std::string& filePathName);
 
 } // namespace
 


### PR DESCRIPTION
In this PR:

- refactoring: moves `Utils` methods related to the window in `SofaGlfwWindow`
- changes the size of the grid (10 times the bounding box)
- makes sure the grid is centered wrt the origin of the scene
- changes the grid alignement wrt the alignement of the camera 

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/192eba4c-d749-4c96-b56c-744d4e8745ca" />
<img width="100%" alt="image" src="https://github.com/user-attachments/assets/d28980d2-53fc-4025-a5fa-5613668f587b" />
<img width="100%" alt="image" src="https://github.com/user-attachments/assets/81ac23e8-1178-43aa-ab1f-072de0a1ab8e" />
<img width="100%" alt="image" src="https://github.com/user-attachments/assets/1f654f5b-390e-4263-8227-c2f6be9dd758" />

TODO:

- improve far clipping rendering 

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/c81cf1aa-572b-4dd1-a1b1-7668213aa910" />
