### PR TITLE
[ProgramWindow] adds icons to start and repeat block

### DIFF
--- a/SofaImGui/src/SofaImGui/models/actions/views/StartMoveView.cpp
+++ b/SofaImGui/src/SofaImGui/models/actions/views/StartMoveView.cpp
@@ -65,7 +65,9 @@ bool StartMove::StartMoveView::showBlock(const std::string &label,
 
         std::string id = "##comment" + std::to_string(window->DC.CursorPos.x);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0., 0., 0., 0.));
-        if (ImGui::InputText(id.c_str(), start.getComment(), models::actions::Action::COMMENTSIZE))
+        std::string text = " " ICON_FA_FLAG"  ";
+        text += start.getComment();
+        if (ImGui::InputText(id.c_str(), text.data(), models::actions::Action::COMMENTSIZE))
         {
             hasValuesChanged = true;
         }

--- a/SofaImGui/src/SofaImGui/models/modifiers/views/RepeatView.cpp
+++ b/SofaImGui/src/SofaImGui/models/modifiers/views/RepeatView.cpp
@@ -20,6 +20,7 @@
  * Contact information: contact@sofa-framework.org                             *
  ******************************************************************************/
 
+#include "IconsFontAwesome6.h"
 #include <SofaImGui/models/modifiers/Repeat.h>
 #include <imgui.h>
 #include <imgui_internal.h>
@@ -76,7 +77,9 @@ bool Repeat::RepeatView::showBlock(const std::string &label,
 
         std::string id = "##comment" + std::to_string(window->DC.CursorPos.x) + std::to_string(window->DC.CursorPos.y);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0., 0., 0., 0.));
-        if (ImGui::InputText(id.c_str(), repeat.getComment(), models::modifiers::Modifier::COMMENTSIZE))
+        std::string text = " " ICON_FA_REPEAT"  ";
+        text += repeat.getComment();
+        if (ImGui::InputText(id.c_str(), text.data(), models::modifiers::Modifier::COMMENTSIZE))
         {
             hasValuesChanged = true;
         }


### PR DESCRIPTION
Similar as #70. 
Adds icons to forgotten blocks:
- `Start waypoint` 
- `Repeat` modifier 

<img width="2987" height="908" alt="image" src="https://github.com/user-attachments/assets/bef00f90-4e6f-4e40-9a33-48b0aeabd8da" />
