### PR TITLE
[ViewportWindow] add view option buttons

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -524,6 +524,7 @@ void ImGuiGUIEngine::showMainMenuBar(sofaglfw::SofaGLFWBaseGUI* baseGUI)
 {
     if (ImGui::BeginMainMenuBar())
     {
+        std::string version = "v" + std::string(SOFA_VERSION_STR);
         menus::FileMenu fileMenu(baseGUI);
         fileMenu.addMenu();
         if (fileMenu.m_loadSimulation) {
@@ -541,7 +542,6 @@ void ImGuiGUIEngine::showMainMenuBar(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         {
             ImGui::PopStyleColor();
 
-
             for (auto& window : m_windows) 
             {
                 bool isViewport = window.get().getName() == m_viewportWindow.getName();
@@ -550,7 +550,9 @@ void ImGuiGUIEngine::showMainMenuBar(sofaglfw::SofaGLFWBaseGUI* baseGUI)
 
                 if(isViewport)
                     ImGui::Separator();
-                ImGui::LocalCheckBox(window.get().getName().c_str(), &window.get().isOpen());
+                auto name = window.get().getName();
+                name.erase(0, sizeof(OFFSET) - 1);
+                ImGui::LocalCheckBox(name.c_str(), &window.get().isOpen());
                 if (isViewport)
                     ImGui::Separator();
 
@@ -570,7 +572,14 @@ void ImGuiGUIEngine::showMainMenuBar(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         if (ImGui::BeginMenu("Help"))
         {
             ImGui::PopStyleColor();
-            if (ImGui::MenuItem("About", nullptr, false, true))
+
+            // Manual
+            std::string url = "https://docs-support.compliance-robotics.com/docs/";
+            url += (version.length()>6)? "next": version;
+            url += "/Users/SOFARobotics/GUI-user-manual/";
+            ImGui::TextLinkOpenURL(ICON_FA_GLOBE" Manual", url.c_str());
+
+            if (ImGui::MenuItem("\t About", nullptr, false, true))
                 isAboutOpen = true;
             ImGui::EndMenu();
         }
@@ -584,7 +593,6 @@ void ImGuiGUIEngine::showMainMenuBar(sofaglfw::SofaGLFWBaseGUI* baseGUI)
             ImGui::Begin("About##SofaComplianceRobotics", &isAboutOpen, ImGuiWindowFlags_NoDocking);
 
             auto windowWidth = ImGui::GetWindowSize().x;
-            std::string version = "v" + std::string(SOFA_VERSION_STR);
             std::vector<std::string> texts = {"\n", "SOFA, Simulation Open-Framework Architecture \n (c) 2006 INRIA, USTL, UJF, CNRS, MGH",
                                               "&", "(c) Compliance Robotics", "\n",
                                               version,

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -49,6 +49,7 @@
 #include <SofaImGui/FooterStatusBar.h>
 #include <SofaImGui/Robot.h>
 
+#define OFFSET "       "
 
 struct GLFWwindow;
 namespace sofa::glfw
@@ -94,14 +95,14 @@ public:
 
     std::shared_ptr<windows::StateWindow> m_stateWindow = std::make_shared<windows::StateWindow>("State", false);
 
-    windows::ViewportWindow     m_viewportWindow     = windows::ViewportWindow("       Viewport", true, m_stateWindow);
-    windows::SceneGraphWindow   m_sceneGraphWindow   = windows::SceneGraphWindow("       Scene Graph", false);
-    windows::LogWindow          m_logWindow          = windows::LogWindow("       Log", false);
-    windows::IOWindow           m_IOWindow           = windows::IOWindow("       Input/Output", false);
-    windows::ProgramWindow      m_programWindow      = windows::ProgramWindow("       Program", true);
-    windows::PlottingWindow     m_plottingWindow     = windows::PlottingWindow("       Plotting", true);
-    windows::MyRobotWindow      m_myRobotWindow      = windows::MyRobotWindow("       My Robot", true);
-    windows::MoveWindow         m_moveWindow         = windows::MoveWindow("       Move", true);
+    windows::ViewportWindow     m_viewportWindow     = windows::ViewportWindow(OFFSET"Viewport", true, m_stateWindow);
+    windows::SceneGraphWindow   m_sceneGraphWindow   = windows::SceneGraphWindow(OFFSET"Scene Graph", false);
+    windows::LogWindow          m_logWindow          = windows::LogWindow(OFFSET"Log", false);
+    windows::IOWindow           m_IOWindow           = windows::IOWindow(OFFSET"Input/Output", false);
+    windows::ProgramWindow      m_programWindow      = windows::ProgramWindow(OFFSET"Program", true);
+    windows::PlottingWindow     m_plottingWindow     = windows::PlottingWindow(OFFSET"Plotting", true);
+    windows::MyRobotWindow      m_myRobotWindow      = windows::MyRobotWindow(OFFSET"My Robot", true);
+    windows::MoveWindow         m_moveWindow         = windows::MoveWindow(OFFSET"Move", true);
 
 
 

--- a/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
+++ b/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
@@ -343,7 +343,7 @@ void ViewMenu::addViewport()
 
 void ViewMenu::addAlignCamera()
 {
-    if (ImGui::BeginMenu("Align Camera"))
+    if (ImGui::BeginMenu("Align View"))
     {
         sofa::component::visual::BaseCamera::SPtr camera;
         const auto& groot = m_baseGUI->getRootNode();
@@ -399,7 +399,7 @@ void ViewMenu::addFullScreen()
 
 void ViewMenu::addCenterCamera()
 {
-    if (ImGui::MenuItem("Center Camera"))
+    if (ImGui::MenuItem("Center View"))
     {
         sofa::component::visual::BaseCamera::SPtr camera;
         const auto& groot = m_baseGUI->getRootNode();
@@ -408,7 +408,8 @@ void ViewMenu::addCenterCamera()
         {
             if( groot->f_bbox.getValue().isValid())
             {
-                camera->fitBoundingBox(groot->f_bbox.getValue().minBBox(), groot->f_bbox.getValue().maxBBox());
+                auto bbCenter = (groot->f_bbox.getValue().maxBBox() + groot->f_bbox.getValue().minBBox()) * 0.5f;
+                camera->d_lookAt.setValue(bbCenter);
             }
             else
             {
@@ -421,7 +422,7 @@ void ViewMenu::addCenterCamera()
 void ViewMenu::addSaveCamera()
 {
     const std::string viewFileName = m_baseGUI->getFilename() + ".view";
-    if (ImGui::MenuItem("Save Camera"))
+    if (ImGui::MenuItem("Save View"))
     {
         sofa::component::visual::BaseCamera::SPtr camera;
         const auto& groot = m_baseGUI->getRootNode();
@@ -445,7 +446,7 @@ void ViewMenu::addRestoreCamera()
     const std::string viewFileName = m_baseGUI->getFilename() + ".view";
     bool fileExists = sofa::helper::system::FileSystem::exists(viewFileName);
     ImGui::BeginDisabled(!fileExists);
-    if (ImGui::MenuItem("Restore Camera"))
+    if (ImGui::MenuItem("Restore View"))
     {
         SofaGLFWWindow::resetSimulationView(m_baseGUI);
     }

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -20,6 +20,8 @@
  * Contact information: contact@sofa-framework.org                             *
  ******************************************************************************/
 
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/component/visual/BaseCamera.h>
 #include <SofaImGui/windows/ViewportWindow.h>
 #include <imgui_internal.h>
 #include <IconsFontAwesome6.h>
@@ -42,7 +44,6 @@ void ViewportWindow::showWindow(sofa::simulation::Node* groot,
     {
         if (ImGui::Begin(m_name.c_str(), &m_isOpen, windowFlags))
         {
-
             ImGui::BeginChild("Render");
             {
                 ImVec2 wsize = ImGui::GetWindowSize();
@@ -84,6 +85,8 @@ void ViewportWindow::showWindow(sofa::simulation::Node* groot,
             ImGui::EndChild();
         }
         ImGui::End();
+
+        addCameraButtons(groot);
     }
 }
 
@@ -91,6 +94,154 @@ void ViewportWindow::addStateWindow()
 {
     ImGui::SetNextWindowPos(ImGui::GetWindowPos());  // attach the state window to top left of the viewport window
     m_stateWindow->showWindow();
+}
+
+void ViewportWindow::addCameraButtons(sofa::simulation::Node* groot)
+{
+    if (ImGui::Begin(m_name.c_str(), &m_isOpen))
+    {
+        if(ImGui::BeginChild("Render"))
+        {
+            auto position = ImGui::GetWindowPos();
+            ImVec2 buttonSize = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
+
+            position.x += ImGui::GetWindowWidth() - buttonSize.x * 2;
+            position.y += buttonSize.y *2. + ImGui::GetStyle().FramePadding.y;
+            ImGui::SetNextWindowPos(position);  // attach the button window to top middle of the viewport window
+
+            auto color = ImGui::GetStyle().Colors[ImGuiCol_TabActive];
+            color.w = 0.6f;
+            ImGui::PushStyleColor(ImGuiCol_WindowBg, ImGui::GetColorU32(color));
+            if (ImGui::Begin("ViewportChildLeftButtons", &m_isOpen,
+                             ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
+            {
+                ImGui::TextDisabled("  " ICON_FA_EYE);
+
+                if (groot)
+                {
+                    sofa::component::visual::BaseCamera::SPtr camera;
+                    groot->get(camera);
+
+                    { // Othographic / perspective view
+                        bool ortho = (camera->getCameraType() == sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE);
+                        if (ImGui::Button((!ortho)? ICON_FA_SQUARE: ICON_FA_CUBE, buttonSize))
+                        {
+                            camera->setCameraType((!ortho)? sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE: sofa::core::visual::VisualParams::PERSPECTIVE_TYPE);
+                        }
+                        ImGui::SetItemTooltip("Orthographic/Perspective");
+                    }
+
+                    { // Center view
+                        if (ImGui::Button(ICON_FA_BULLSEYE, buttonSize))
+                        {
+                            auto bbCenter = (groot->f_bbox.getValue().maxBBox() + groot->f_bbox.getValue().minBBox()) * 0.5f;
+                            camera->d_lookAt.setValue(bbCenter);
+                        }
+                        ImGui::SetItemTooltip("Center view");
+                    }
+
+                    { // Align view
+                        if (ImGui::Button(ICON_FA_ARROWS_TO_DOT, buttonSize))
+                        {
+                            camera->d_orientation.setValue(sofa::type::Quat(0., 0., 0., 1.));
+                        }
+                        ImGui::SetItemTooltip("Align view");
+                    }
+
+                    { // Axis related
+                        ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
+                        ImGui::PushStyleColor(ImGuiCol_BorderShadow, ImVec4(0, 0, 0, 0));
+                        { // Translate X
+                            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(1, 0, 0, 1));
+                            ImGui::Button(ICON_FA_ARROWS_LEFT_RIGHT"##TranslateX", buttonSize);
+                            if (ImGui::IsItemActive())
+                            {
+                                sofa::type::Vec3 t = sofa::type::Vec3(ImGui::GetIO().MouseDelta.x, 0., 0.);
+                                camera->translate(t);
+                                camera->translateLookAt(t);
+                            }
+                            ImGui::SetItemTooltip("Translate along X");
+                            ImGui::PopStyleColor();
+                        }
+
+                        { // Translate Y
+                            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 1, 0, 1));
+                            ImGui::Button(ICON_FA_ARROWS_LEFT_RIGHT"##TranslateY", buttonSize);
+                            if (ImGui::IsItemActive())
+                            {
+                                sofa::type::Vec3 t = sofa::type::Vec3(0., ImGui::GetIO().MouseDelta.x, 0.);
+                                camera->translate(t);
+                                camera->translateLookAt(t);
+                            }
+                            ImGui::SetItemTooltip("Translate along Y");
+                            ImGui::PopStyleColor();
+                        }
+
+                        { // Translate Z
+                            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 1, 1));
+                            ImGui::Button(ICON_FA_ARROWS_LEFT_RIGHT"##TranslateZ", buttonSize);
+                            if (ImGui::IsItemActive())
+                            {
+                                sofa::type::Vec3 t = sofa::type::Vec3(0., 0., ImGui::GetIO().MouseDelta.x);
+                                camera->translate(t);
+                                camera->translateLookAt(t);
+                            }
+                            ImGui::SetItemTooltip("Translate along Z");
+                            ImGui::PopStyleColor();
+                        }
+
+                        const auto& cameraPosition = camera->d_position.getValue();
+                        const auto &lookAt = (camera->d_lookAt.isSet())? camera->getLookAt(): camera->getLookAtFromOrientation(cameraPosition, camera->getDistance(), camera->getOrientation());
+                        { // Rotate X
+                            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(1, 0, 0, 1));
+                            ImGui::Button(ICON_FA_ROTATE_LEFT"##RotateX", buttonSize);
+                            if (ImGui::IsItemActive())
+                            {
+                                sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0.001 * ImGui::GetIO().MouseDelta.x, 0., 0., 1.);
+                                camera->rotateCameraAroundPoint(q, lookAt);
+                            }
+                            ImGui::SetItemTooltip("Rotate around X");
+                            ImGui::PopStyleColor();
+                        }
+
+                        { // Rotate Y
+                            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 1, 0, 1));
+                            ImGui::Button(ICON_FA_ROTATE_LEFT"##RotateY", buttonSize);
+                            if (ImGui::IsItemActive())
+                            {
+                                sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., 0.001 * ImGui::GetIO().MouseDelta.x, 0., 1.);
+                                camera->rotateCameraAroundPoint(q, lookAt);
+                            }
+                            ImGui::SetItemTooltip("Rotate around Y");
+                            ImGui::PopStyleColor();
+                        }
+
+                        { // Rotate Z
+                            ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0, 0, 1, 1));
+                            ImGui::Button(ICON_FA_ROTATE_LEFT"##RotateZ", buttonSize);
+                            if (ImGui::IsItemActive())
+                            {
+                                sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., 0., 0.001 * ImGui::GetIO().MouseDelta.x, 1.);
+                                camera->rotateCameraAroundPoint(q, lookAt);
+                            }
+                            ImGui::SetItemTooltip("Rotate around Z");
+                            ImGui::PopStyleColor();
+                        }
+                        auto orientation = camera->getOrientation();
+                        const double distance = (lookAt - cameraPosition).norm();
+                        camera->d_position.setValue(lookAt - orientation.rotate(sofa::type::Vec3(0,0,-distance)));
+
+                        ImGui::PopStyleColor();
+                        ImGui::PopStyleVar();
+                    }
+                }
+            }
+            ImGui::End();
+            ImGui::PopStyleColor();
+            ImGui::EndChild();
+        }
+    }
+    ImGui::End();
 }
 
 bool ViewportWindow::addStepButton()
@@ -122,7 +273,6 @@ bool ViewportWindow::addStepButton()
                 }
                 ImGui::End();
                 ImGui::PopStyleColor();
-
                 ImGui::EndChild();
             }
         }

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.h
@@ -36,7 +36,8 @@ class SOFAIMGUI_API ViewportWindow : public BaseWindow
 
     void showWindow(sofa::simulation::Node *groot, const ImTextureID& texture,
                     const ImGuiWindowFlags &windowFlags);
-    
+
+    void addCameraButtons(sofa::simulation::Node *groot);
     bool addStepButton();
     bool addAnimateButton(bool *animate);
     bool addDrivingTabCombo(int *mode, const char *listModes[], const int &sizeListModes);


### PR DESCRIPTION
**In this PR**
- Adds link to the manual
- Cleans window name visual
- Adds options for the camera
- Change wording for user: "camera" to "view"

**Screenshots**

<img width="25%" alt="image" src="https://github.com/user-attachments/assets/aeb37337-f6c1-41af-9d39-40d474de7ac6" />

<img width="20%" alt="image" src="https://github.com/user-attachments/assets/dfdea541-a7f5-4c6c-b269-15722e284e8f" />

<img width="20%" alt="image" src="https://github.com/user-attachments/assets/63c00a16-6578-41bf-9e38-26981340b49b" />

<img width="2887" height="1678" alt="image" src="https://github.com/user-attachments/assets/0f9af733-df44-4521-b15a-292c522ee599" />


