### PR TITLE
[SofaImGui] Create a node for the GUI

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -618,7 +618,7 @@ void SofaGLFWBaseGUI::cursor_position_callback(GLFWwindow* window, double xpos, 
         auto currentSofaWindow = s_mapWindows.find(window);
         if (currentSofaWindow != s_mapWindows.end() && currentSofaWindow->second)
         {
-            currentSofaWindow->second->mouseMoveEvent(currentGUI->second->getRootNode(), static_cast<int>(xpos), static_cast<int>(ypos));
+            currentSofaWindow->second->mouseMoveEvent(currentGUI->second, static_cast<int>(xpos), static_cast<int>(ypos));
         }
     }
 }

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -108,6 +108,10 @@ public:
         }
     }
 
+    const char* getGUINodeName() {
+        return "GUI";
+    }
+
 private:
     // GLFW callbacks
     static void error_callback(int error, const char* description);

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -97,15 +97,18 @@ void SofaGLFWWindow::draw(sofa::simulation::NodeSPtr groot, sofa::core::visual::
     sofa::simulation::node::draw(vparams, groot.get());
 }
 
+
 void SofaGLFWWindow::setBackgroundColor(const sofa::type::RGBAColor& newColor)
 {
     m_backgroundColor = newColor;
 }
 
+
 void SofaGLFWWindow::setCamera(sofa::component::visual::BaseCamera::SPtr newCamera)
 {
     m_currentCamera = newCamera;
 }
+
 
 void SofaGLFWWindow::centerCamera(sofa::simulation::NodeSPtr node, sofa::core::visual::VisualParams* vparams) const
 {
@@ -156,129 +159,152 @@ void SofaGLFWWindow::resetSimulationView(sofaglfw::SofaGLFWBaseGUI *baseGUI)
 }
 
 
-void SofaGLFWWindow::alignCamera(sofa::simulation::NodeSPtr groot, const CameraAlignement& align)
+void SofaGLFWWindow::alignCamera(sofaglfw::SofaGLFWBaseGUI* baseGUI, const CameraAlignement& align)
 {
-    sofa::component::visual::BaseCamera::SPtr camera;
-    groot->get(camera);
-
-    if (camera)
+    if (baseGUI)
     {
-        sofa::type::Quat<float> orientation;
-
-        switch(align)
+        sofa::core::sptr<sofa::simulation::Node> groot = baseGUI->getRootNode();
+        if (groot)
         {
-        case TOP:
-            orientation = sofa::type::Quat(-0.707, 0., 0., 0.707);
-            setGridsPlane(groot);
-            break;
-        case BOTTOM:
-            orientation = sofa::type::Quat(0.707, 0., 0., 0.707);
-            setGridsPlane(groot);
-            break;
-        case FRONT:
-            orientation = sofa::type::Quat(0., 0., 0., 1.);
-            setGridsPlane(groot, VisualGrid::PlaneType("z"));
-            break;
-        case BACK:
-            orientation = sofa::type::Quat(0., 1., 0., 0.);
-            setGridsPlane(groot, VisualGrid::PlaneType("z"));
-            break;
-        case LEFT:
-            orientation = sofa::type::Quat(0., 0.707, 0., 0.707);
-            setGridsPlane(groot, VisualGrid::PlaneType("x"));
-            break;
-        case RIGHT:
-            orientation = sofa::type::Quat(0., -0.707, 0., 0.707);
-            setGridsPlane(groot, VisualGrid::PlaneType("x"));
-            break;
-        }
+            sofa::component::visual::BaseCamera::SPtr camera;
+            groot->get(camera);
 
-        auto bbCenter = (groot->f_bbox.getValue().maxBBox() + groot->f_bbox.getValue().minBBox()) * 0.5f;
-        const auto& cameraPosition = camera->getPositionFromOrientation(sofa::type::Vec3(0., 0., 0.), -camera->getDistance(), orientation);
-        camera->setView(cameraPosition + bbCenter, orientation);
-        camera->d_lookAt.setValue(bbCenter);
-        camera->setCameraType(sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE);
-    }
-}
-
-void SofaGLFWWindow::setGridsPlane(sofa::simulation::NodeSPtr groot, const VisualGrid::PlaneType &plane)
-{
-    if (groot)
-    {
-        auto squareSizes = GridSquareSize::getSquareSizes();
-        for (const auto& squareSize: squareSizes)
-        {
-            auto grid = groot->get<sofa::component::visual::VisualGrid>(std::string("ViewportGrid" + GridSquareSize::getString(squareSize)));
-            if (grid)
-                grid->d_plane.setValue(plane);
-        }
-    }
-}
-
-void SofaGLFWWindow::mouseMoveEvent(sofa::simulation::NodeSPtr groot, int xpos, int ypos)
-{
-    switch (m_currentAction)
-    {
-    case GLFW_PRESS:
-    {
-        sofa::core::objectmodel::MouseEvent* mEvent = nullptr;
-        if (m_currentButton == GLFW_MOUSE_BUTTON_LEFT)
-            mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::LeftPressed, xpos, ypos);
-        else if (m_currentButton == GLFW_MOUSE_BUTTON_RIGHT)
-            mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::RightPressed, xpos, ypos);
-        else if (m_currentButton == GLFW_MOUSE_BUTTON_MIDDLE)
-            mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::MiddlePressed, xpos, ypos);
-        else {
-            // A fallback event to rule them all...
-            mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::AnyExtraButtonPressed, xpos, ypos);
-        }
-        m_currentCamera->manageEvent(mEvent);
-        m_currentXPos = xpos;
-        m_currentYPos = ypos;
-
-        // If we rotate the view, we should use the perspective mode
-        if(m_currentCamera->d_activated.getValue())
-        {
-            if(mEvent->getState() == sofa::core::objectmodel::MouseEvent::LeftPressed)
+            if (camera)
             {
-                m_currentCamera->setCameraType(sofa::core::visual::VisualParams::PERSPECTIVE_TYPE);
-                setGridsPlane(groot);
+                sofa::type::Quat<float> orientation;
+
+                switch (align)
+                {
+                case TOP:
+                    orientation = sofa::type::Quat(-0.707, 0., 0., 0.707);
+                    setGridsPlane(baseGUI);
+                    break;
+                case BOTTOM:
+                    orientation = sofa::type::Quat(0.707, 0., 0., 0.707);
+                    setGridsPlane(baseGUI);
+                    break;
+                case FRONT:
+                    orientation = sofa::type::Quat(0., 0., 0., 1.);
+                    setGridsPlane(baseGUI, VisualGrid::PlaneType("z"));
+                    break;
+                case BACK:
+                    orientation = sofa::type::Quat(0., 1., 0., 0.);
+                    setGridsPlane(baseGUI, VisualGrid::PlaneType("z"));
+                    break;
+                case LEFT:
+                    orientation = sofa::type::Quat(0., 0.707, 0., 0.707);
+                    setGridsPlane(baseGUI, VisualGrid::PlaneType("x"));
+                    break;
+                case RIGHT:
+                    orientation = sofa::type::Quat(0., -0.707, 0., 0.707);
+                    setGridsPlane(baseGUI, VisualGrid::PlaneType("x"));
+                    break;
+                }
+
+                auto bbCenter = (groot->f_bbox.getValue().maxBBox() + groot->f_bbox.getValue().minBBox()) * 0.5f;
+                const auto& cameraPosition = camera->getPositionFromOrientation(sofa::type::Vec3(0., 0., 0.), -camera->getDistance(), orientation);
+                camera->setView(cameraPosition + bbCenter, orientation);
+                camera->d_lookAt.setValue(bbCenter);
+                camera->setCameraType(sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE);
             }
         }
-
-        break;
     }
-    case GLFW_RELEASE:
-    {
-        sofa::core::objectmodel::MouseEvent* mEvent = nullptr;
-        if (m_currentButton == GLFW_MOUSE_BUTTON_LEFT)
-            mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::LeftReleased, xpos, ypos);
-        else if (m_currentButton == GLFW_MOUSE_BUTTON_RIGHT)
-            mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::RightReleased, xpos, ypos);
-        else if (m_currentButton == GLFW_MOUSE_BUTTON_MIDDLE)
-            mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::MiddleReleased, xpos, ypos);
-        else {
-            // A fallback event to rules them all...
-            mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::AnyExtraButtonReleased, xpos, ypos);
-        }
-        m_currentCamera->manageEvent(mEvent);
-        m_currentXPos = xpos;
-        m_currentYPos = ypos;
-        break;
-    }
-
-    default:
-    {
-        sofa::core::objectmodel::MouseEvent me(sofa::core::objectmodel::MouseEvent::Move, xpos, ypos);
-        m_currentCamera->manageEvent(&me);
-        break;
-    }
-    }
-
-    m_currentButton = -1;
-    m_currentAction = -1;
-    m_currentMods = -1;
 }
+
+
+void SofaGLFWWindow::setGridsPlane(sofaglfw::SofaGLFWBaseGUI* baseGUI, const VisualGrid::PlaneType &plane)
+{
+    if (baseGUI)
+    {
+        sofa::core::sptr<sofa::simulation::Node> groot = baseGUI->getRootNode();
+        if (groot)
+        {
+            auto guiNode = groot->getChild(baseGUI->getGUINodeName());
+            if (guiNode)
+            {
+                auto squareSizes = GridSquareSize::getSquareSizes();
+                for (const auto& squareSize : squareSizes)
+                {
+                    auto grid = guiNode->get<sofa::component::visual::VisualGrid>(std::string("ViewportGrid" + GridSquareSize::getString(squareSize)));
+                    if (grid)
+                        grid->d_plane.setValue(plane);
+                }
+            }
+        }
+    }
+}
+
+
+void SofaGLFWWindow::mouseMoveEvent(sofaglfw::SofaGLFWBaseGUI* baseGUI, int xpos, int ypos)
+{
+    if (baseGUI)
+    {
+        sofa::core::sptr<sofa::simulation::Node> groot = baseGUI->getRootNode();
+
+        switch (m_currentAction)
+        {
+        case GLFW_PRESS:
+        {
+            sofa::core::objectmodel::MouseEvent* mEvent = nullptr;
+            if (m_currentButton == GLFW_MOUSE_BUTTON_LEFT)
+                mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::LeftPressed, xpos, ypos);
+            else if (m_currentButton == GLFW_MOUSE_BUTTON_RIGHT)
+                mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::RightPressed, xpos, ypos);
+            else if (m_currentButton == GLFW_MOUSE_BUTTON_MIDDLE)
+                mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::MiddlePressed, xpos, ypos);
+            else {
+                // A fallback event to rule them all...
+                mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::AnyExtraButtonPressed, xpos, ypos);
+            }
+            m_currentCamera->manageEvent(mEvent);
+            m_currentXPos = xpos;
+            m_currentYPos = ypos;
+
+            // If we rotate the view, we should use the perspective mode
+            if (m_currentCamera->d_activated.getValue())
+            {
+                if (mEvent->getState() == sofa::core::objectmodel::MouseEvent::LeftPressed)
+                {
+                    m_currentCamera->setCameraType(sofa::core::visual::VisualParams::PERSPECTIVE_TYPE);
+                    setGridsPlane(baseGUI);
+                }
+            }
+
+            break;
+        }
+        case GLFW_RELEASE:
+        {
+            sofa::core::objectmodel::MouseEvent* mEvent = nullptr;
+            if (m_currentButton == GLFW_MOUSE_BUTTON_LEFT)
+                mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::LeftReleased, xpos, ypos);
+            else if (m_currentButton == GLFW_MOUSE_BUTTON_RIGHT)
+                mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::RightReleased, xpos, ypos);
+            else if (m_currentButton == GLFW_MOUSE_BUTTON_MIDDLE)
+                mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::MiddleReleased, xpos, ypos);
+            else {
+                // A fallback event to rules them all...
+                mEvent = new sofa::core::objectmodel::MouseEvent(sofa::core::objectmodel::MouseEvent::AnyExtraButtonReleased, xpos, ypos);
+            }
+            m_currentCamera->manageEvent(mEvent);
+            m_currentXPos = xpos;
+            m_currentYPos = ypos;
+            break;
+        }
+
+        default:
+        {
+            sofa::core::objectmodel::MouseEvent me(sofa::core::objectmodel::MouseEvent::Move, xpos, ypos);
+            m_currentCamera->manageEvent(&me);
+            break;
+        }
+        }
+
+        m_currentButton = -1;
+        m_currentAction = -1;
+        m_currentMods = -1;
+    }
+}
+
 
 void SofaGLFWWindow::mouseButtonEvent(int button, int action, int mods)
 {

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
@@ -43,7 +43,7 @@ public:
     void draw(sofa::simulation::NodeSPtr groot, sofa::core::visual::VisualParams* vparams);
     void close();
 
-    void mouseMoveEvent(sofa::simulation::NodeSPtr groot, int xpos, int ypos);
+    void mouseMoveEvent(sofaglfw::SofaGLFWBaseGUI* baseGUI, int xpos, int ypos);
     void mouseButtonEvent(int button, int action, int mods);
     void scrollEvent(double xoffset, double yoffset);
     void setBackgroundColor(const sofa::type::RGBAColor& newColor);
@@ -79,8 +79,8 @@ public:
     };
 
     static void resetSimulationView(sofaglfw::SofaGLFWBaseGUI *baseGUI);
-    static void alignCamera(sofa::simulation::NodeSPtr groot, const CameraAlignement &align);
-    static void setGridsPlane(sofa::simulation::NodeSPtr groot, const VisualGrid::PlaneType &plane = VisualGrid::PlaneType("y"));
+    static void alignCamera(sofaglfw::SofaGLFWBaseGUI* baseGUI, const CameraAlignement &align);
+    static void setGridsPlane(sofaglfw::SofaGLFWBaseGUI* baseGUI, const VisualGrid::PlaneType &plane = VisualGrid::PlaneType("y"));
 
 private:
     GLFWwindow* m_glfwWindow{nullptr};

--- a/SofaGLFW/src/SofaGLFW/initSofaGLFW.cpp
+++ b/SofaGLFW/src/SofaGLFW/initSofaGLFW.cpp
@@ -69,7 +69,7 @@ const char* getModuleLicense()
 
 const char* getModuleDescription()
 {
-    return "A GLFW Gui for SOFA.";
+    return "A GLFW GUI for SOFA.";
 }
 
 const char* getModuleComponentList()

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -80,22 +80,12 @@
 #include <SofaImGui/Utils.h>
 #include <SofaImGui/widgets/Widgets.h>
 
-#include <sofa/helper/Utils.h>
-#include <sofa/type/vector.h>
-#include <sofa/simulation/Node.h>
-#include <sofa/component/visual/VisualStyle.h>
-#include <sofa/core/ComponentLibrary.h>
 #include <sofa/core/ObjectFactory.h>
-#include <sofa/helper/system/PluginManager.h>
-#include <SofaImGui/ObjectColor.h>
-#include <sofa/core/visual/VisualParams.h>
-#include <sofa/helper/io/File.h>
-#include <sofa/component/visual/VisualGrid.h>
-#include <sofa/component/visual/LineAxis.h>
-#include <sofa/gui/common/BaseGUI.h>
-#include <sofa/helper/io/STBImage.h>
 #include <sofa/simulation/graph/DAGNode.h>
 #include <sofa/version.h>
+
+#include <SofaGLFW/init.h>
+
 
 using namespace sofa;
 
@@ -284,6 +274,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         m_IOWindow.setSimulationState(m_simulationState);
         m_stateWindow->setSimulationState(m_simulationState);
         enableWindows();
+        createGUINode();
     }
     else
     {
@@ -735,37 +726,43 @@ void ImGuiGUIEngine::key_callback(GLFWwindow* window, int key, int scancode, int
 
     if(m_viewportWindow.isFocusOnViewport() && action==GLFW_PRESS)
     {
-        const auto& groot = m_baseGUI->getRootNode();
         switch (key)
         {
         case GLFW_KEY_0:
         {
             sofa::component::visual::BaseCamera::SPtr camera;
-            groot->get(camera);
-            const auto& bbox = groot->f_bbox.getValue();
+            const auto& groot = m_baseGUI->getRootNode();
+            if (groot)
+            {
+                groot->get(camera);
 
-            camera->fitBoundingBox(bbox.minBBox(), bbox.maxBBox());
-            auto bbCenter = (bbox.maxBBox() + bbox.minBBox()) * 0.5f;
-            camera->d_lookAt.setValue(bbCenter);
+                if (camera)
+                {
+                    const auto& bbox = groot->f_bbox.getValue();
+                    camera->fitBoundingBox(bbox.minBBox(), bbox.maxBBox());
+                    auto bbCenter = (bbox.maxBBox() + bbox.minBBox()) * 0.5f;
+                    camera->d_lookAt.setValue(bbCenter);
+                }
+            }
             break;
         }
         case GLFW_KEY_1:
-            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::TOP);
+            sofaglfw::SofaGLFWWindow::alignCamera(m_baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::TOP);
             break;
         case GLFW_KEY_2:
-            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::BOTTOM);
+            sofaglfw::SofaGLFWWindow::alignCamera(m_baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::BOTTOM);
             break;
         case GLFW_KEY_3:
-            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::FRONT);
+            sofaglfw::SofaGLFWWindow::alignCamera(m_baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::FRONT);
             break;
         case GLFW_KEY_4:
-            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::BACK);
+            sofaglfw::SofaGLFWWindow::alignCamera(m_baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::BACK);
             break;
         case GLFW_KEY_5:
-            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::RIGHT);
+            sofaglfw::SofaGLFWWindow::alignCamera(m_baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::RIGHT);
             break;
         case GLFW_KEY_6:
-            sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::LEFT);
+            sofaglfw::SofaGLFWWindow::alignCamera(m_baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::LEFT);
             break;
         }
     }
@@ -775,9 +772,27 @@ void ImGuiGUIEngine::loadSimulation(const bool& reload, const std::string& filen
 {
     clearGUI();
     Utils::loadSimulation(m_baseGUI, reload, filename);
+    createGUINode();
     m_IOWindow.setSimulationState(m_simulationState);
     m_stateWindow->setSimulationState(m_simulationState);
     enableWindows();
+}
+
+void ImGuiGUIEngine::createGUINode()
+{
+    const char* nodeName = m_baseGUI->getGUINodeName();
+    sofa::simulation::Node::SPtr root = m_baseGUI->getRootNode();
+    if (root)
+    {
+        sofa::simulation::Node::SPtr guinode = root->getChild(nodeName);
+        if (!guinode)
+        {
+            guinode = root->createChild(nodeName);
+        }
+        guinode->addTag(sofa::core::objectmodel::Tag("NoBBox"));
+        guinode->addTag(sofa::core::objectmodel::Tag("createdByGUI"));
+        guinode->f_bbox.setParent(&root->f_bbox);
+    }
 }
 
 void ImGuiGUIEngine::enableWindows()

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -131,6 +131,7 @@ protected:
     void saveSettings();
     void loadSimulation(const bool& reload, const std::string &filename);
     void enableWindows();
+    void createGUINode();
     void clearGUI();
     void setDockSizeFromFile(const ImGuiID& id);
 

--- a/SofaImGui/src/SofaImGui/init.h
+++ b/SofaImGui/src/SofaImGui/init.h
@@ -26,4 +26,5 @@
 namespace sofaimgui
 {
     SOFAIMGUI_API void init();
+
 } // namespace sofaimgui

--- a/SofaImGui/src/SofaImGui/initSofaImGui.cpp
+++ b/SofaImGui/src/SofaImGui/initSofaImGui.cpp
@@ -69,7 +69,7 @@ const char* getModuleLicense()
 
 const char* getModuleDescription()
 {
-    return "A ImGui Gui for SOFA.";
+    return "A ImGui GUI for SOFA.";
 }
 
 const char* getModuleComponentList()

--- a/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
+++ b/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
@@ -40,8 +40,7 @@
 #include <filesystem>
 #include <SofaImGui/Utils.h>
 #include <SofaImGui/widgets/Widgets.h>
-#include <SofaImGui/Utils.h>
-#include <tinyxml2.h>
+
 
 namespace sofaimgui::menus {
 
@@ -115,28 +114,32 @@ void ViewMenu::showGrid(const bool& show, const float& squareSize, const float& 
             return;
         }
 
-        std::string name = "ViewportGrid" + SofaGLFWWindow::GridSquareSize::getString(squareSize);
-        auto grid = groot->get<sofa::component::visual::VisualGrid>(name);
-        if (!grid)
+        auto guiNode = groot->getChild(m_baseGUI->getGUINodeName());
+        if (guiNode)
         {
-            auto newGrid = sofa::core::objectmodel::New<sofa::component::visual::VisualGrid>();
-            groot->addObject(newGrid);
-            newGrid->setName(name);
-            newGrid->addTag(sofa::core::objectmodel::Tag("createdByGUI"));
-            newGrid->d_enable.setValue(show);
-            newGrid->d_size.setValue(gridSize);
-            newGrid->d_thickness.setValue(thickness);
-            newGrid->d_nbSubdiv.setValue(gridSize / squareSize);
-            newGrid->d_color.setValue(color);
-            newGrid->init();
-        }
-        else
-        {
-            grid->d_enable.setValue(show);
+            std::string name = "ViewportGrid" + SofaGLFWWindow::GridSquareSize::getString(squareSize);
+            auto grid = guiNode->get<sofa::component::visual::VisualGrid>(name);
+            if (!grid)
+            {
+                auto newGrid = sofa::core::objectmodel::New<sofa::component::visual::VisualGrid>();
+                guiNode->addObject(newGrid);
+                newGrid->setName(name);
+                newGrid->addTag(sofa::core::objectmodel::Tag("createdByGUI"));
+                newGrid->d_enable.setValue(show);
+                newGrid->d_size.setValue(gridSize);
+                newGrid->d_thickness.setValue(thickness);
+                newGrid->d_nbSubdiv.setValue(gridSize / squareSize);
+                newGrid->d_color.setValue(color);
+                newGrid->init();
+            }
+            else
+            {
+                grid->d_enable.setValue(show);
+            }
         }
     }
 
-    sofaglfw::SofaGLFWWindow::setGridsPlane(groot);
+    sofaglfw::SofaGLFWWindow::setGridsPlane(m_baseGUI);
 }
 
 void ViewMenu::showOriginFrame(const bool& show)
@@ -144,21 +147,26 @@ void ViewMenu::showOriginFrame(const bool& show)
     const auto& groot = m_baseGUI->getRootNode();
     if (groot)
     {
-        auto originFrame = groot->get<sofa::component::visual::LineAxis>();
-        if(!originFrame)
+        auto guiNode = groot->getChild(m_baseGUI->getGUINodeName());
+        if (guiNode)
         {
-            auto newOriginFrame = sofa::core::objectmodel::New<sofa::component::visual::LineAxis>();
-            groot->addObject(newOriginFrame);
-            newOriginFrame->setName("ViewportOriginFrame");
-            newOriginFrame->addTag(sofa::core::objectmodel::Tag("createdByGUI"));
-            newOriginFrame->d_enable.setValue(show);
-            newOriginFrame->d_infinite.setValue(true);
-            newOriginFrame->d_thickness.setValue(2.f);
-            newOriginFrame->d_vanishing.setValue(true);
-            newOriginFrame->init();
-        } else
-        {
-            originFrame->d_enable.setValue(show);
+            auto originFrame = guiNode->get<sofa::component::visual::LineAxis>();
+            if (!originFrame)
+            {
+                auto newOriginFrame = sofa::core::objectmodel::New<sofa::component::visual::LineAxis>();
+                guiNode->addObject(newOriginFrame);
+                newOriginFrame->setName("ViewportOriginFrame");
+                newOriginFrame->addTag(sofa::core::objectmodel::Tag("createdByGUI"));
+                newOriginFrame->d_enable.setValue(show);
+                newOriginFrame->d_infinite.setValue(true);
+                newOriginFrame->d_thickness.setValue(2.f);
+                newOriginFrame->d_vanishing.setValue(true);
+                newOriginFrame->init();
+            }
+            else
+            {
+                originFrame->d_enable.setValue(show);
+            }
         }
     }
 }
@@ -168,20 +176,24 @@ void ViewMenu::showBoundingBox(const bool& show)
     const auto& groot = m_baseGUI->getRootNode();
     if (groot)
     {
-        auto bbox = groot->get<sofa::component::visual::VisualBoundingBox>();
-        if (!bbox)
+        auto guiNode = groot->getChild(m_baseGUI->getGUINodeName());
+        if (guiNode)
         {
-            auto newBBox = sofa::core::objectmodel::New<sofa::component::visual::VisualBoundingBox>();
-            groot->addObject(newBBox);
-            newBBox->setName("VisualBoundingBox");
-            newBBox->d_enable.setValue(show);
-            newBBox->f_bbox.setParent(&groot->f_bbox);
-            newBBox->d_color.setValue(sofa::type::RGBAColor::white());
-            newBBox->d_thickness.setValue(1.0f);
-        }
-        else
-        {
-            bbox->d_enable.setValue(show);
+            auto bbox = guiNode->get<sofa::component::visual::VisualBoundingBox>();
+            if (!bbox)
+            {
+                auto newBBox = sofa::core::objectmodel::New<sofa::component::visual::VisualBoundingBox>();
+                guiNode->addObject(newBBox);
+                newBBox->setName("VisualBoundingBox");
+                newBBox->d_enable.setValue(show);
+                newBBox->f_bbox.setParent(&groot->f_bbox);
+                newBBox->d_color.setValue(sofa::type::RGBAColor::white());
+                newBBox->d_thickness.setValue(1.0f);
+            }
+            else
+            {
+                bbox->d_enable.setValue(show);
+            }
         }
     }
 }
@@ -357,39 +369,38 @@ void ViewMenu::addAlignCamera(sofa::component::visual::BaseCamera::SPtr camera)
     {
         if (camera)
         {
-            const auto& groot = m_baseGUI->getRootNode();
             if (ImGui::MenuItem("Top", "1"))
             {
-                SofaGLFWWindow::alignCamera(groot, SofaGLFWWindow::CameraAlignement::TOP);
+                SofaGLFWWindow::alignCamera(m_baseGUI, SofaGLFWWindow::CameraAlignement::TOP);
             }
 
             if (ImGui::MenuItem("Bottom", "2"))
             {
-                SofaGLFWWindow::alignCamera(groot, SofaGLFWWindow::CameraAlignement::BOTTOM);
+                SofaGLFWWindow::alignCamera(m_baseGUI, SofaGLFWWindow::CameraAlignement::BOTTOM);
             }
 
             ImGui::Separator();
 
             if (ImGui::MenuItem("Front", "3"))
             {
-                SofaGLFWWindow::alignCamera(groot, SofaGLFWWindow::CameraAlignement::FRONT);
+                SofaGLFWWindow::alignCamera(m_baseGUI, SofaGLFWWindow::CameraAlignement::FRONT);
             }
 
             if (ImGui::MenuItem("Back", "4"))
             {
-                SofaGLFWWindow::alignCamera(groot, SofaGLFWWindow::CameraAlignement::BACK);
+                SofaGLFWWindow::alignCamera(m_baseGUI, SofaGLFWWindow::CameraAlignement::BACK);
             }
 
             ImGui::Separator();
 
             if (ImGui::MenuItem("Left", "5"))
             {
-                SofaGLFWWindow::alignCamera(groot, SofaGLFWWindow::CameraAlignement::LEFT);
+                SofaGLFWWindow::alignCamera(m_baseGUI, SofaGLFWWindow::CameraAlignement::LEFT);
             }
 
             if (ImGui::MenuItem("Right", "6"))
             {
-                SofaGLFWWindow::alignCamera(groot, SofaGLFWWindow::CameraAlignement::RIGHT);
+                SofaGLFWWindow::alignCamera(m_baseGUI, SofaGLFWWindow::CameraAlignement::RIGHT);
             }
         }
         ImGui::EndMenu();

--- a/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
+++ b/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
@@ -40,6 +40,7 @@
 #include <filesystem>
 #include <SofaImGui/Utils.h>
 #include <SofaImGui/widgets/Widgets.h>
+#include <tinyxml2.h>
 
 
 namespace sofaimgui::menus {

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -178,17 +178,17 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
                 sofaimgui::widget::SetRect(position.x, position.y, frameGizmoSize);
                 sofaimgui::widget::DrawFrameGizmo(mview, proj, axisClicked);
                 if (axisClicked[0])
-                    sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::LEFT);
+                    sofaglfw::SofaGLFWWindow::alignCamera(baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::LEFT);
                 else if (axisClicked[1])
-                    sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::TOP);
+                    sofaglfw::SofaGLFWWindow::alignCamera(baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::TOP);
                 else if (axisClicked[2])
-                    sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::FRONT);
+                    sofaglfw::SofaGLFWWindow::alignCamera(baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::FRONT);
                 else if (axisClicked[3])
-                    sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::RIGHT);
+                    sofaglfw::SofaGLFWWindow::alignCamera(baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::RIGHT);
                 else if (axisClicked[4])
-                    sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::BOTTOM);
+                    sofaglfw::SofaGLFWWindow::alignCamera(baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::BOTTOM);
                 else if (axisClicked[5])
-                    sofaglfw::SofaGLFWWindow::alignCamera(groot, sofaglfw::SofaGLFWWindow::CameraAlignement::BACK);
+                    sofaglfw::SofaGLFWWindow::alignCamera(baseGUI, sofaglfw::SofaGLFWWindow::CameraAlignement::BACK);
             }
 
             { // Orientation gizmo


### PR DESCRIPTION
**Current problem:**
We use the VisualGrid to understand and visualize the scene distance unit and to quickly measure distances when analyzing a simulation. For aesthetic purposes, our grids are set to be n times larger than the scene bounding box.
The `VisualGrid` component contributes to the scene bounding box by default.

**In this PR:**
- Creates a node for the GUI
- This node is tagged not to update the BBox
- The components created by the GUI are added in this node
- Cleaning: removes unused includes

**Screenshot:**
<img width="3409" height="2018" alt="image" src="https://github.com/user-attachments/assets/ab3d207e-350f-4556-b10b-e5078c220972" />
