### PR TITLE
[SofaImGui] Widget: adds missing float widget

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiDataWidget.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiDataWidget.cpp
@@ -59,6 +59,12 @@ void DataWidget<bool>::showWidget(MyData& data)
 }
 
 template<>
+void DataWidget<float>::showWidget(MyData& data)
+{
+    showScalarWidget(data);
+}
+
+template<>
 void DataWidget<double>::showWidget(MyData& data)
 {
     showScalarWidget(data);

--- a/SofaImGui/src/SofaImGui/widgets/ScalarWidget.h
+++ b/SofaImGui/src/SofaImGui/widgets/ScalarWidget.h
@@ -29,17 +29,13 @@ namespace sofaimgui
 
 inline bool showScalarWidget(const std::string& label, const std::string& id, float& value)
 {
-    ImGui::PushItemWidth(-1); // Fit container width
-    bool result = ImGui::LocalInputFloat((label + "##" + id).c_str(), &value, 0.0f, 0.0f, "%.8f", ImGuiInputTextFlags_None);
-    ImGui::PopItemWidth();
+    bool result = ImGui::LocalInputFloat((label + "##" + id).c_str(), &value, 0.0f, 0.0f, "", ImGuiInputTextFlags_None);
     return result;
 }
 
 inline bool showScalarWidget(const std::string& label, const std::string& id, double& value)
 {
-    ImGui::PushItemWidth(-1); // Fit container width
-    bool result = ImGui::LocalInputDouble((label + "##" + id).c_str(), &value, 0.0f, 0.0f, "%.8f", ImGuiInputTextFlags_None);
-    ImGui::PopItemWidth();
+    bool result = ImGui::LocalInputDouble((label + "##" + id).c_str(), &value, 0.0f, 0.0f, "", ImGuiInputTextFlags_None);
     return result;
 }
 

--- a/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
+++ b/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
@@ -22,7 +22,7 @@ bool LocalInputDouble(const char* label, double* v, double step, double step_fas
 
     ImGui::PushItemWidth(inputWidth);
     ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
-    const char* format = (abs(*v)!=0. && (log10f(abs(*v))>3 || log10f(abs(*v))<-3))? "%0.2e": "%0.2f";
+    const char* format = (abs(*v)!=0. && (log10f(abs(*v))>3 || log10f(abs(*v))<-2))? "%0.2e": "%0.2f";
     bool result =  ImGui::InputDouble(label, v, step, step_fast, format, flags);
     ImGui::PopStyleVar();
     ImGui::PopItemWidth();
@@ -38,7 +38,7 @@ bool LocalInputFloat(const char* label, float* v, float step, float step_fast, c
 
     ImGui::PushItemWidth(inputWidth);
     ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
-    const char* format = (abs(*v)!=0. && (log10f(abs(*v))>3 || log10f(abs(*v))<-3))? "%0.2e": "%0.2f";
+    const char* format = (abs(*v)!=0. && (log10f(abs(*v))>3 || log10f(abs(*v))<-2))? "%0.2e": "%0.2f";
     bool result =  ImGui::InputFloat(label, v, step, step_fast, format, flags);
     ImGui::PopStyleVar();
     ImGui::PopItemWidth();


### PR DESCRIPTION
**Problem**
Float data were not editable in the component's window.

**In this PR**
Adds the missing template.
And fixes scientific format.