### PR TITLE
[SofaGLFW] use ctrl+shift for keyboard events

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -600,6 +600,7 @@ void SofaGLFWBaseGUI::key_callback(GLFWwindow* window, int key, int scancode, in
 {
     const char sofaKey = SofaGLFWBaseGUI::handleArrowKeys(key);
     const bool isCtrlKeyPressed = glfwGetKey(window, GLFW_KEY_LEFT_CONTROL) == GLFW_PRESS;
+    const bool isShiftKeyPressed = glfwGetKey(window, GLFW_KEY_LEFT_SHIFT ) == GLFW_PRESS;
 
     auto currentGUI = s_mapGUIs.find(window);
     if (currentGUI == s_mapGUIs.end() || currentGUI->second == nullptr)
@@ -614,12 +615,10 @@ void SofaGLFWBaseGUI::key_callback(GLFWwindow* window, int key, int scancode, in
         return;
     }
 
-    if (isCtrlKeyPressed)
+    if (isCtrlKeyPressed && isShiftKeyPressed)
     {
         if (action == GLFW_PRESS)
         {
-            dmsg_info_when(key == GLFW_KEY_LEFT_CONTROL, "SofaGLFWBaseGUI") << "KeyPressEvent, CONTROL pressed";
-
             sofa::core::objectmodel::KeypressedEvent keyPressedEvent(sofaKey);
             rootNode->propagateEvent(sofa::core::ExecParams::defaultInstance(), &keyPressedEvent);
         }
@@ -667,14 +666,7 @@ void SofaGLFWBaseGUI::key_callback(GLFWwindow* window, int key, int scancode, in
     const char* keyName = glfwGetKeyName(key, scancode);
     if (keyName)
     {
-        if(strcmp(keyName, "f") == 0)
-        {
-            if (action == GLFW_PRESS && (mods & GLFW_MOD_CONTROL))
-            {
-                currentGUI->second->switchFullScreen(window);
-            }
-        }
-        else if (strcmp(keyName, "q") == 0)
+        if (strcmp(keyName, "q") == 0)
         {
             if (action == GLFW_PRESS && isCtrlKeyPressed)
             {

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -666,11 +666,14 @@ void SofaGLFWBaseGUI::key_callback(GLFWwindow* window, int key, int scancode, in
     const char* keyName = glfwGetKeyName(key, scancode);
     if (keyName)
     {
-        if (strcmp(keyName, "q") == 0)
+        if (isCtrlKeyPressed && !isShiftKeyPressed)
         {
-            if (action == GLFW_PRESS && isCtrlKeyPressed)
+            if (strcmp(keyName, "q") == 0)
             {
-                glfwSetWindowShouldClose(window, GLFW_TRUE);
+                if (action == GLFW_PRESS )
+                {
+                    glfwSetWindowShouldClose(window, GLFW_TRUE);
+                }
             }
         }
     }


### PR DESCRIPTION
Applies parts of https://github.com/sofa-framework/SofaGLFW/pull/242:

- enforce the use of CTRL + SHIFT to propage key events to SOFA
- remove the use of F key to go full screen, F11 is preferred

Not applied: 
- CTRL + B to change the background