### PR TITLE
[SofaImGui] Format LocalTextLinkOpenURL and add useful links

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -634,7 +634,7 @@ void ImGuiGUIEngine::showMainMenuBar(sofaglfw::SofaGLFWBaseGUI* baseGUI)
             std::string url = "https://docs-support.compliance-robotics.com/docs/";
             url += (version.length()>6)? "next": version;
             url += "/Users/SOFARobotics/GUI-user-manual/";
-            ImGui::TextLinkOpenURL(ICON_FA_GLOBE" Manual", url.c_str());
+            ImGui::LocalTextLinkOpenURL("Manual", url.c_str());
 
             if (ImGui::MenuItem("\t About...", nullptr, false, true))
                 isAboutOpen = true;

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -631,10 +631,16 @@ void ImGuiGUIEngine::showMainMenuBar(sofaglfw::SofaGLFWBaseGUI* baseGUI)
             ImGui::PopStyleColor();
 
             // Manual
-            std::string url = "https://docs-support.compliance-robotics.com/docs/";
-            url += (version.length()>6)? "next": version;
-            url += "/Users/SOFARobotics/GUI-user-manual/";
-            ImGui::LocalTextLinkOpenURL("Manual", url.c_str());
+            std::string manualURL = "https://docs-support.compliance-robotics.com/docs/";
+            manualURL += (version.length()>6)? "next": version;
+            manualURL += "/Users/SOFARobotics/GUI-user-manual/";
+            ImGui::LocalTextLinkOpenURL("Sofa Robotics Manual", manualURL.c_str());
+
+            // Sofa Robotics GitHub
+            ImGui::LocalTextLinkOpenURL("Sofa Robotics GitHub", "https://github.com/SofaComplianceRobotics/SofaGLFW/tree/robotics");
+
+            // Compliance Robotics Website
+            ImGui::LocalTextLinkOpenURL("Compliance Robotics", "https://compliance-robotics.com/");
 
             if (ImGui::MenuItem("\t About...", nullptr, false, true))
                 isAboutOpen = true;
@@ -663,6 +669,10 @@ void ImGuiGUIEngine::showMainMenuBar(sofaglfw::SofaGLFWBaseGUI* baseGUI)
                 ImGui::SetCursorPosX((windowWidth - textWidth) * 0.5f);
                 ImGui::Text("%s", text.c_str());
             }
+
+            // Support SOFA
+            ImGui::LocalTextLinkOpenURL("Support SOFA", "https://www.sofa-framework.org/consortium/support-us/");
+
             ImGui::End();
         }
 

--- a/SofaImGui/src/SofaImGui/menus/FileMenu.cpp
+++ b/SofaImGui/src/SofaImGui/menus/FileMenu.cpp
@@ -181,7 +181,7 @@ bool FileMenu::addImportExportProgram()
     if (!engine->m_programWindow.isEnabledInWorkbench())
         ImGui::BeginDisabled();
 
-    if (ImGui::MenuItem("Import Program", "Ctrl+Shift+I"))
+    if (ImGui::MenuItem("Import Program...", "Ctrl+Shift+I"))
         engine->m_programWindow.importProgram();
 
     if (ImGui::MenuItem("Export Program", "Ctrl+Shift+E"))
@@ -207,7 +207,7 @@ void FileMenu::saveProject()
 
     }
 
-    if (ImGui::MenuItem("Save As", "Ctrl+Shift+S"))
+    if (ImGui::MenuItem("Save As...", "Ctrl+Shift+S"))
     {
 
     }

--- a/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
+++ b/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
@@ -1,3 +1,4 @@
+#include "IconsFontAwesome6.h"
 #include <sofa/helper/logging/Messaging.h>
 #include <SofaImGui/widgets/Widgets.h>
 #include <string>
@@ -220,6 +221,14 @@ void LocalEndCollapsingHeader()
 {
     ImGui::Spacing();
     ImGui::Unindent();
+}
+
+void LocalTextLinkOpenURL(const char* label, const char* url)
+{
+    std::string _label = ICON_FA_GLOBE" Open ";
+    _label += label;
+    _label += "...";
+    TextLinkOpenURL(_label.c_str(), url);
 }
 
 void Block(const char* label, const ImRect &bb, const ImVec4 &color, const float &offset)

--- a/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
+++ b/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
@@ -225,7 +225,7 @@ void LocalEndCollapsingHeader()
 
 void LocalTextLinkOpenURL(const char* label, const char* url)
 {
-    std::string _label = ICON_FA_GLOBE" Open ";
+    std::string _label = ICON_FA_GLOBE" ";
     _label += label;
     TextLinkOpenURL(_label.c_str(), url);
 }

--- a/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
+++ b/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
@@ -227,7 +227,6 @@ void LocalTextLinkOpenURL(const char* label, const char* url)
 {
     std::string _label = ICON_FA_GLOBE" Open ";
     _label += label;
-    _label += "...";
     TextLinkOpenURL(_label.c_str(), url);
 }
 

--- a/SofaImGui/src/SofaImGui/widgets/Widgets.h
+++ b/SofaImGui/src/SofaImGui/widgets/Widgets.h
@@ -36,6 +36,9 @@ bool LocalBeginCollapsingHeader(const char* label, ImGuiTreeNodeFlags flags);
 /// Ends a local collapsing header, removing the indentation added when expanded.
 void LocalEndCollapsingHeader();
 
+/// Format: ICON_FA_GLOBE Open label...
+void LocalTextLinkOpenURL(const char* label, const char* url);
+
 // ProgramWindow widgets
 
 /// Draws a colored block with a title area.

--- a/SofaImGui/src/SofaImGui/widgets/Widgets.h
+++ b/SofaImGui/src/SofaImGui/widgets/Widgets.h
@@ -36,7 +36,7 @@ bool LocalBeginCollapsingHeader(const char* label, ImGuiTreeNodeFlags flags);
 /// Ends a local collapsing header, removing the indentation added when expanded.
 void LocalEndCollapsingHeader();
 
-/// Format: ICON_FA_GLOBE Open label...
+/// Format: ICON_FA_GLOBE Open label
 void LocalTextLinkOpenURL(const char* label, const char* url);
 
 // ProgramWindow widgets

--- a/SofaImGui/src/SofaImGui/windows/ComponentsWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ComponentsWindow.cpp
@@ -20,6 +20,7 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 
+#include <SofaImGui/widgets/Widgets.h>
 #include <SofaImGui/windows/ComponentsWindow.h>
 #include <filesystem>
 #include <sofa/simulation/graph/DAGNode.h>
@@ -170,9 +171,9 @@ void ComponentsWindow::showComponentInfo(sofa::core::ClassEntry::SPtr selectedCo
 
     if (!selectedComponent->documentationURL.empty())
     {
-        ImGui::TextDisabled("Documentation URL:");
+        ImGui::TextDisabled("Documentation:");
         ImGui::SameLine();
-        ImGui::TextLinkOpenURL("link", selectedComponent->documentationURL.c_str());
+        ImGui::LocalTextLinkOpenURL("Documentation", selectedComponent->documentationURL.c_str());
     }
 
     if (!m_selectedComponentExamples.empty())

--- a/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
@@ -844,7 +844,7 @@ void SceneGraphWindow::addBaseContextMenu(sofa::core::objectmodel::Base *object)
 
         if (!instantiationFilename.empty())
         {
-            if(ImGui::MenuItem("Open Instantiation File..."))
+            if(ImGui::MenuItem("Open Instantiation File"))
             {
                 if (sofa::helper::system::FileSystem::openFileWithDefaultApplication(instantiationFilename))
                     FooterStatusBar::getInstance().setTempMessage("Opening file : " + instantiationFilename);
@@ -855,7 +855,7 @@ void SceneGraphWindow::addBaseContextMenu(sofa::core::objectmodel::Base *object)
 
         if (!implementationFilename.empty())
         {
-            if(ImGui::MenuItem("Open Implementation File..."))
+            if(ImGui::MenuItem("Open Implementation File"))
             {
                 if(sofa::helper::system::FileSystem::openFileWithDefaultApplication(implementationFilename))
                     FooterStatusBar::getInstance().setTempMessage("Opening file : " + implementationFilename);

--- a/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
@@ -585,6 +585,9 @@ bool SceneGraphWindow::showComponentWindow(sofa::core::objectmodel::BaseObject* 
                     ImGui::TextDisabled("Type:");
                     ImGui::TextWrapped("%s", component->getClassName().c_str());
                     ImGui::Spacing();
+                    ImGui::TextDisabled("Documentation:");
+                    addComponentDocTextLinkOpenURL(component);
+                    ImGui::Spacing();
                     ImGui::TextDisabled("Linkpath:");
                     ImGui::TextWrapped("@%s", component->getPathName().c_str());
                     ImGui::Spacing();
@@ -658,6 +661,18 @@ bool SceneGraphWindow::showNodeWindow(sofa::simulation::Node* node, const ImGuiW
     ImGui::End();
     ImGui::PopStyleVar();
     return isOpen;
+}
+
+void SceneGraphWindow::addComponentDocTextLinkOpenURL(sofa::core::objectmodel::BaseObject *component)
+{
+    sofa::core::ObjectFactory::ClassEntry entry = sofa::core::ObjectFactory::getInstance()->getEntry(component->getClassName());
+    if (!entry.creatorMap.empty())
+    {
+        if (!entry.documentationURL.empty() && entry.documentationURL != std::string("TODO"))
+        {
+            ImGui::LocalTextLinkOpenURL("Documentation", entry.documentationURL.c_str());
+        }
+    }
 }
 
 void SceneGraphWindow::addGroupTab(const std::map<std::string, std::vector<sofa::core::BaseData*> >& groupMap)
@@ -808,6 +823,10 @@ void SceneGraphWindow::addComponentContextMenu(sofa::core::objectmodel::BaseObje
     if (component)
     {
         addBaseContextMenu(component);
+
+        ImGui::Separator();
+
+        addComponentDocTextLinkOpenURL(component);
     }
 }
 
@@ -818,7 +837,7 @@ void SceneGraphWindow::addBaseContextMenu(sofa::core::objectmodel::Base *object)
         const std::string instantiationFilename = object->getInstanciationSourceFileName();
         const std::string implementationFilename = object->getDefinitionSourceFileName();
 
-        if(ImGui::MenuItem("Copy Scene Graph Path"))
+        if(ImGui::MenuItem("Copy Linkpath"))
             ImGui::SetClipboardText(object->getPathName().c_str());
 
         ImGui::Separator();

--- a/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.h
@@ -54,6 +54,8 @@ protected:
     bool showComponentWindow(sofa::core::objectmodel::BaseObject* component, const ImGuiWindowFlags &windowsFlags);
     bool showNodeWindow(sofa::simulation::Node* node, const ImGuiWindowFlags &windowsFlags);
 
+    void addComponentDocTextLinkOpenURL(sofa::core::objectmodel::BaseObject *component);
+
     void addGroupTab(const std::map<std::string, std::vector<sofa::core::BaseData*> >& groupMap);
     void addLinksTab(const sofa::core::objectmodel::Base::VecLink& links);
     void addMessagesTab(const std::deque<sofa::helper::logging::Message> &messages, const std::string& name, const std::string &icon);


### PR DESCRIPTION
Applies parts of https://github.com/sofa-framework/SofaGLFW/pull/265 and  https://github.com/sofa-framework/SofaGLFW/pull/266, plus some standardization:

- Adds "Open Documentation" in component context menu
- Add additional links
- Standardization:
    - `Linkpath`, to match the python API **(? not sure about that one)**
    - `Documentation` instead of documentation url, link, documentation link etc...
    - `LocalTextLinkOpenURL`, format proposition: `ICON_FA_GLOBE label`. 
    - Correct usage of "...". According to Apple: “Use an ellipsis whenever choosing a menu item requires additional input from the user. The ellipsis character (…) means a dialog or separate window will open and prompt the user for additional information or to make a choice.”

<img width="3840" height="2234" alt="image" src="https://github.com/user-attachments/assets/ab30775c-2f95-4c5d-9f7b-bf1f96c53019" />


<img width="50%" alt="image" src="https://github.com/user-attachments/assets/c36a04d3-183f-4526-b12b-08fe99398a97" />

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/ea1b0375-bb33-4ac0-ac4c-1fa1ef860a5f" />



