### PR TITLE
[SofaImGui] Cleaning simulation driving window

### DIFF
--- a/SofaImGui/CMakeLists.txt
+++ b/SofaImGui/CMakeLists.txt
@@ -154,6 +154,7 @@ set(HEADER_FILES
     ${SOFAIMGUI_SOURCE_DIR}/ObjectColor.h
 
     ${SOFAIMGUI_SOURCE_DIR}/Utils.h
+    ${SOFAIMGUI_SOURCE_DIR}/DrivingWindow.h
     ${SOFAIMGUI_SOURCE_DIR}/FooterStatusBar.h
     ${SOFAIMGUI_SOURCE_DIR}/Robot.h
     ${SOFAIMGUI_SOURCE_DIR}/Workbench.h
@@ -213,6 +214,7 @@ set(SOURCE_FILES
     ${SOFAIMGUI_SOURCE_DIR}/ImGuiGUI.cpp
     ${SOFAIMGUI_SOURCE_DIR}/ImGuiGUIEngine.cpp
     ${SOFAIMGUI_SOURCE_DIR}/ObjectColor.cpp
+    ${SOFAIMGUI_SOURCE_DIR}/DrivingWindow.cpp
     ${SOFAIMGUI_SOURCE_DIR}/Utils.cpp
     ${SOFAIMGUI_SOURCE_DIR}/FooterStatusBar.cpp
     ${SOFAIMGUI_SOURCE_DIR}/Robot.cpp

--- a/SofaImGui/src/SofaImGui/DrivingWindow.cpp
+++ b/SofaImGui/src/SofaImGui/DrivingWindow.cpp
@@ -19,52 +19,11 @@
  *                                                                             *
  * Contact information: contact@sofa-framework.org                             *
  ******************************************************************************/
-#pragma once
 
-#include <SofaImGui/windows/BaseWindow.h>
-#include <SofaImGui/windows/StateWindow.h>
-#include <SofaImGui/menus/ViewMenu.h>
-#include <imgui.h>
+#include <SofaImGui/DrivingWindow.h>
 
-namespace sofaimgui::windows {
+namespace sofaimgui {
 
-class SOFAIMGUI_API ViewportWindow : public BaseWindow
-{
-   public:
-
-    ViewportWindow(const std::string& name, const bool& isWindowOpen, std::shared_ptr<StateWindow> stateWindow);
-    ~ViewportWindow() = default;
-
-    void showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImTextureID& texture, const ImGuiWindowFlags &windowFlags);
-    std::string getDescription() override;
-
-    void addCameraButtons(sofaglfw::SofaGLFWBaseGUI *baseGUI, sofa::simulation::Node *groot);
-    bool addAnimateButton(bool *animate, const float& shift_x);
-    bool addStepButton();
-    bool addDrivingTabCombo(int *mode, const char *listModes[], const int &sizeListModes);
-
-    std::pair<float, float> m_windowSize{0., 0.};
-
-    bool isMouseOnViewport() {return m_isMouseOnViewport;}
-    bool isFocusOnViewport() {return m_isFocusOnViewport;}
-
-   protected:
-
-    menus::ViewMenu m_viewmenu = menus::ViewMenu(nullptr);
-    std::shared_ptr<StateWindow> m_stateWindow;
-    float m_fps{0.f};
-
-    bool m_isMouseOnViewport{false};
-    bool m_isFocusOnViewport{false};
-
-    double m_maxPanelItemWidth{0.0};
-
-    void addStateWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWindowFlags &windowFlags);
-    void addSimulationTimeAndFPS(sofa::simulation::Node *groot);
-    bool checkCamera(sofa::simulation::Node* groot);
-    void addContextMenu(const ImTextureID& texture);
-};
+DrivingWindow drivingWindow = DrivingWindow::MOVE;
 
 }
-
-

--- a/SofaImGui/src/SofaImGui/DrivingWindow.h
+++ b/SofaImGui/src/SofaImGui/DrivingWindow.h
@@ -21,50 +21,40 @@
  ******************************************************************************/
 #pragma once
 
-#include <SofaImGui/windows/BaseWindow.h>
-#include <SofaImGui/windows/StateWindow.h>
-#include <SofaImGui/menus/ViewMenu.h>
-#include <imgui.h>
+#include <SofaImGui/config.h>
 
-namespace sofaimgui::windows {
+namespace sofaimgui {
 
-class SOFAIMGUI_API ViewportWindow : public BaseWindow
-{
-   public:
+constexpr int getDrivingWindowCount() { return 4; }
 
-    ViewportWindow(const std::string& name, const bool& isWindowOpen, std::shared_ptr<StateWindow> stateWindow);
-    ~ViewportWindow() = default;
-
-    void showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImTextureID& texture, const ImGuiWindowFlags &windowFlags);
-    std::string getDescription() override;
-
-    void addCameraButtons(sofaglfw::SofaGLFWBaseGUI *baseGUI, sofa::simulation::Node *groot);
-    bool addAnimateButton(bool *animate, const float& shift_x);
-    bool addStepButton();
-    bool addDrivingTabCombo(int *mode, const char *listModes[], const int &sizeListModes);
-
-    std::pair<float, float> m_windowSize{0., 0.};
-
-    bool isMouseOnViewport() {return m_isMouseOnViewport;}
-    bool isFocusOnViewport() {return m_isFocusOnViewport;}
-
-   protected:
-
-    menus::ViewMenu m_viewmenu = menus::ViewMenu(nullptr);
-    std::shared_ptr<StateWindow> m_stateWindow;
-    float m_fps{0.f};
-
-    bool m_isMouseOnViewport{false};
-    bool m_isFocusOnViewport{false};
-
-    double m_maxPanelItemWidth{0.0};
-
-    void addStateWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWindowFlags &windowFlags);
-    void addSimulationTimeAndFPS(sofa::simulation::Node *groot);
-    bool checkCamera(sofa::simulation::Node* groot);
-    void addContextMenu(const ImTextureID& texture);
+// Driving window for Robotics Simulation GUI
+enum DrivingWindow {
+    NONE    = 0,
+    MOVE    = 1, // 1. Move Window - For moving the robot using sliders.
+    PROGRAM = 2, // 2. Program Window - For programming the robot using a block based timeline.
+    IO      = 3  // 3. IO Window - For piloting the robot from input / output data.
 };
 
+// Function to get the names of the DrivingWindow enum as strings
+inline const char* getDrivingWindowName(DrivingWindow drivingWindow) {
+    switch (drivingWindow) {
+    case MOVE: return "Move";
+    case PROGRAM: return "Program";
+    case IO: return "Input/Output";
+    default: return "None";
+    }
 }
 
+// Function to get the description of the Workbench enum as strings
+inline const char* getDrivingWindowDescription(DrivingWindow drivingWindow) {
+    switch (drivingWindow) {
+    case MOVE: return "For moving the robot using sliders.";
+    case PROGRAM: return "For programming the robot using a block based timeline.";
+    case IO: return "For piloting the robot from input / output data.";
+    default: return "None";
+    }
+}
 
+extern DrivingWindow drivingWindow;
+
+}

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -23,6 +23,7 @@
 #include <SofaImGui/ObjectColor.h>
 #include <SofaImGui/ImGuiDataWidget.h>
 #include <SofaImGui/ImGuiGUIEngine.h>
+#include <SofaImGui/DrivingWindow.h>
 #include <SofaImGui/Workbench.h>
 #include <SofaImGui/AppIniFile.h>
 
@@ -477,9 +478,10 @@ void ImGuiGUIEngine::showViewportWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI)
     if (workbench != Workbench::SCENE_EDITOR)
     {
         m_animate = groot->animate_.getValue();
+        const float shift_x = ImGui::GetFrameHeightWithSpacing() * (m_IPController? 3: 1);
 
         // Animate button
-        if (m_viewportWindow.addAnimateButton(&m_animate))
+        if (m_viewportWindow.addAnimateButton(&m_animate, shift_x))
             sofa::helper::getWriteOnlyAccessor(groot->animate_).wref() = m_animate;
 
         // Step button
@@ -497,40 +499,45 @@ void ImGuiGUIEngine::showViewportWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         }
 
         // Driving Tab combo
-        static const char* listTabs[]{"Move", "Program", "Input/Output"};
-
-        if(!m_IPController)
-            ImGui::BeginDisabled();
-
-        if (m_viewportWindow.addDrivingTabCombo(&m_mode, listTabs, IM_ARRAYSIZE(listTabs)))
+        if(m_IPController)
         {
-            const auto filename = baseGUI->getFilename();
+            int dWindow = drivingWindow;
+            static const char* listTabs[getDrivingWindowCount()];
+            for (sofa::Index i=0; i<getDrivingWindowCount(); i++)
+                listTabs[i] = getDrivingWindowName(DrivingWindow(i));
 
-            m_moveWindow.setDrivingTCPTarget(false);
-            m_programWindow.setDrivingTCPTarget(false);
-            m_IOWindow.setDrivingTCPTarget(false);
-            switch (m_mode) {
-            case 1:
+            if (m_viewportWindow.addDrivingTabCombo(&dWindow, listTabs, IM_ARRAYSIZE(listTabs)))
             {
-                m_programWindow.setTime(groot->getTime());
-                m_programWindow.setDrivingTCPTarget(true);
-                break;
-            }
-            case 2:
-            {
-                m_IOWindow.setDrivingTCPTarget(true);
-                break;
-            }
-            default:
-            {
-                m_moveWindow.setDrivingTCPTarget(true);
-                break;
-            }
+                drivingWindow = DrivingWindow(dWindow);
+                const auto filename = baseGUI->getFilename();
+
+                m_moveWindow.setDrivingTCPTarget(false);
+                m_programWindow.setDrivingTCPTarget(false);
+                m_IOWindow.setDrivingTCPTarget(false);
+                switch (drivingWindow) {
+                    case DrivingWindow::MOVE:
+                    {
+                        m_moveWindow.setDrivingTCPTarget(true);
+                        break;
+                    }
+                    case DrivingWindow::PROGRAM:
+                    {
+                        m_programWindow.setTime(groot->getTime());
+                        m_programWindow.setDrivingTCPTarget(true);
+                        break;
+                    }
+                    case DrivingWindow::IO:
+                    {
+                        m_IOWindow.setDrivingTCPTarget(true);
+                        break;
+                    }
+                    default:
+                    {
+                        break;
+                    }
+                }
             }
         }
-
-        if(!m_IPController)
-            ImGui::EndDisabled();
     }
 }
 

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -502,41 +502,12 @@ void ImGuiGUIEngine::showViewportWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         if(m_IPController)
         {
             int dWindow = drivingWindow;
-            static const char* listTabs[getDrivingWindowCount()];
+            const char* listTabs[getDrivingWindowCount()];
             for (sofa::Index i=0; i<getDrivingWindowCount(); i++)
                 listTabs[i] = getDrivingWindowName(DrivingWindow(i));
 
             if (m_viewportWindow.addDrivingTabCombo(&dWindow, listTabs, IM_ARRAYSIZE(listTabs)))
-            {
                 drivingWindow = DrivingWindow(dWindow);
-                const auto filename = baseGUI->getFilename();
-
-                m_moveWindow.setDrivingTCPTarget(false);
-                m_programWindow.setDrivingTCPTarget(false);
-                m_IOWindow.setDrivingTCPTarget(false);
-                switch (drivingWindow) {
-                    case DrivingWindow::MOVE:
-                    {
-                        m_moveWindow.setDrivingTCPTarget(true);
-                        break;
-                    }
-                    case DrivingWindow::PROGRAM:
-                    {
-                        m_programWindow.setTime(groot->getTime());
-                        m_programWindow.setDrivingTCPTarget(true);
-                        break;
-                    }
-                    case DrivingWindow::IO:
-                    {
-                        m_IOWindow.setDrivingTCPTarget(true);
-                        break;
-                    }
-                    default:
-                    {
-                        break;
-                    }
-                }
-            }
         }
     }
 }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -113,6 +113,7 @@ public:
     windows::MouseManagerWindow m_mouseManagerWindow = windows::MouseManagerWindow("Mouse Manager", false);
 
 protected:
+
     std::unique_ptr<sofa::gl::FrameBufferObject> m_fbo;
     std::pair<unsigned int, unsigned int> m_currentFBOSize;
 
@@ -151,7 +152,6 @@ protected:
     models::IPController::SPtr m_IPController;
     models::SimulationState m_simulationState;
     bool m_animate{false};
-    int m_mode{0};
     bool m_darkMode{false};
     sofaglfw::SofaGLFWBaseGUI* m_baseGUI{nullptr};
     std::vector<ImGuiID> m_dockIDs;

--- a/SofaImGui/src/SofaImGui/windows/BaseWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/BaseWindow.cpp
@@ -41,11 +41,6 @@ void BaseWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI, const ImGuiWindo
     SOFA_UNUSED(windowFlags);
 }
 
-void BaseWindow::setDrivingTCPTarget(const bool &isDrivingSimulation)
-{
-    m_isDrivingSimulation = isDrivingSimulation;
-}
-
 std::string BaseWindow::getName() const
 {
     return m_name;
@@ -55,11 +50,6 @@ std::string& BaseWindow::getLabel()
 {
     m_labelname = "       " + m_name;
     return m_labelname;
-}
-
-bool BaseWindow::isDrivingSimulation()
-{
-    return m_isDrivingSimulation;
 }
 
 bool& BaseWindow::isOpen()

--- a/SofaImGui/src/SofaImGui/windows/BaseWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/BaseWindow.h
@@ -88,9 +88,6 @@ class SOFAIMGUI_API BaseWindow
     /// Will be displayed as a tooltip
     virtual std::string getDescription() = 0;
 
-    /// Set the window as able to drive the robot in simulation.
-    virtual void setDrivingTCPTarget(const bool &isDrivingSimulation);
-
     /// This is called before loading / reloading a simulation.
     virtual void clearWindow() {}
 
@@ -99,9 +96,6 @@ class SOFAIMGUI_API BaseWindow
 
     /// Get the label of the window (name to display in the tab). We add spaces for aesthetic reason
     std::string& getLabel();
-
-    /// Does the window have tools to drive the robot in simulation.
-    bool isDrivingSimulation();
 
     /// Set the user choice to open the window or not.
     void setOpen(const bool &isOpen);
@@ -127,7 +121,6 @@ class SOFAIMGUI_API BaseWindow
     bool m_isOpen{false}; /// The user choice to open the window or not
     std::string m_name = "Window"; /// The name of the window
     std::string m_labelname; /// The label of the window
-    bool m_isDrivingSimulation{false}; /// Does the window have tools to drive the robot in simulation
     bool m_defaultIsOpen{false}; /// The default open state when there is no project file
     int m_workbenches;
 

--- a/SofaImGui/src/SofaImGui/windows/IOWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/IOWindow.cpp
@@ -650,7 +650,7 @@ void IOWindow::animateBeginEventROS(sofa::simulation::Node *groot)
     {
         rclcpp::spin_some(m_rosnode);  // Create a default single-threaded executor and execute any immediately available work.
 
-        if(m_IPController && m_isDrivingSimulation) // If the window is driving the simulation
+        if(m_IPController && isDrivingSimulation()) // If the window is driving the simulation
         {
             // Overwrite the TCPTarget with ROS input
             for (const auto& [stateName, stateValue]: m_rosnode->m_selectedDataToOverwrite)

--- a/SofaImGui/src/SofaImGui/windows/IOWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/IOWindow.h
@@ -28,6 +28,7 @@
 #include <SofaImGui/windows/BaseWindow.h>
 #include <SofaImGui/models/SimulationState.h>
 #include <SofaImGui/Workbench.h>
+#include <SofaImGui/DrivingWindow.h>
 #include <imgui.h>
 
 #if SOFAIMGUI_WITH_ROS
@@ -178,6 +179,8 @@ class SOFAIMGUI_API IOWindow : public BaseWindow
 
     /// Update ROS input lists with the topics selected from the GUI
     void updateROSInput();
+
+    bool isDrivingSimulation() {return drivingWindow == DrivingWindow::IO;}
 
     std::map<std::string, bool> m_publishListboxItems;
     std::map<std::string, bool> m_subcriptionListboxItems;

--- a/SofaImGui/src/SofaImGui/windows/LogWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/LogWindow.cpp
@@ -47,7 +47,6 @@ LogWindow::LogWindow(const std::string& name, const bool& isWindowOpen)
     m_defaultIsOpen = false;
     m_name = name;
     m_isOpen = isWindowOpen;
-    m_isDrivingSimulation = false;
 }
 
 std::string LogWindow::getDescription()

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
@@ -40,7 +40,6 @@ MoveWindow::MoveWindow(const std::string& name,
     m_defaultIsOpen = true;
     m_name = name;
     m_isOpen = isWindowOpen;
-    m_isDrivingSimulation = true;
     m_moveType = MoveType::SLIDERS;
 
     m_movePad = ImGui::MovePad("##MovePad", "X", "Z", "Y",
@@ -122,7 +121,7 @@ void MoveWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI, const ImGuiWindo
                 {
                     ImGui::Spacing();
 
-                    if(m_isDrivingSimulation)
+                    if(isDrivingSimulation())
                         m_IPController->getTCPTargetPosition(m_x, m_y, m_z, m_rx, m_ry, m_rz);
 
                     if (ImGui::CollapsingHeader(m_TCPPositionDescription.c_str(), ImGuiTreeNodeFlags_DefaultOpen))
@@ -219,7 +218,7 @@ void MoveWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI, const ImGuiWindo
                         ImGui::LocalEndCollapsingHeader();
                     }
 
-                    if (m_isDrivingSimulation)
+                    if (isDrivingSimulation())
                     {
                         sofa::type::Quat<SReal> q = m_IPController->getTCPPosition().getOrientation();
                         sofa::type::Vec3 rotation = q.toEulerVector();
@@ -264,7 +263,7 @@ void MoveWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI, const ImGuiWindo
                                 actuator.value=buffer;
                             }
                         }
-                        if (m_IPController && !solveInverseProblem && m_isDrivingSimulation)
+                        if (m_IPController && !solveInverseProblem && isDrivingSimulation())
                         {
                             // TODO: don't solve the inverse problem since we'll overwrite the solution
                             m_IPController->applyActuatorsForce(m_actuators);
@@ -293,7 +292,7 @@ void MoveWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI, const ImGuiWindo
                                                                ("##Input" + name).c_str(),
                                                                &buffer, accessory.min, accessory.max,
                                                                ImVec4(0, 0, 0, 0));
-                            if (hasChanged && m_isDrivingSimulation)
+                            if (hasChanged && isDrivingSimulation())
                             {
                                 accessory.data->read(std::to_string(buffer));
                             }

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.h
@@ -24,6 +24,7 @@
 #include <SofaImGui/windows/BaseWindow.h>
 #include <SofaImGui/models/IPController.h>
 #include <SofaImGui/widgets/MovePad.h>
+#include <SofaImGui/DrivingWindow.h>
 #include <imgui.h>
 
 namespace sofaimgui::windows {
@@ -101,6 +102,7 @@ class SOFAIMGUI_API MoveWindow : public BaseWindow
     void showWeightOption(const int &index);
     void showPad(sofaglfw::SofaGLFWBaseGUI* baseGUI);
     bool showVerticalTab(const std::string& label, const std::string& tooltip, const bool &active);
+    bool isDrivingSimulation() {return drivingWindow == DrivingWindow::MOVE;}
 };
 
 }

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
@@ -45,7 +45,6 @@ MyRobotWindow::MyRobotWindow(const std::string& name,
     m_defaultIsOpen = true;
     m_name = name;
     m_isOpen = isWindowOpen;
-    m_isDrivingSimulation = true;
 }
 
 std::string MyRobotWindow::getDescription()

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
@@ -264,7 +264,7 @@ void ProgramWindow::showCursorMarker(const int& nbCollaspedTracks)
     m_cursorPos = m_time * ProgramSizes().TimelineOneSecondSize;
 
     // On animate, follow the cursor marker
-    if (m_baseGUI->getRootNode()->getAnimate() && m_isDrivingSimulation)
+    if (m_baseGUI->getRootNode()->getAnimate() && isDrivingSimulation())
     {
         float step = m_cursorPos - (ImGui::GetWindowContentRegionMax().x + ImGui::GetScrollX() - borderSize - m_trackBeginPos.x);
         if (step > 0)
@@ -868,7 +868,7 @@ void ProgramWindow::saveProgramDirAndFilename(const std::string& filename)
 
 void ProgramWindow::stepProgram(const double &dt, const bool &reverse)
 {
-    if (m_isDrivingSimulation)
+    if (isDrivingSimulation())
     {
         double eps = 1e-5;
         for (const auto& track: m_program.getTracks())
@@ -896,7 +896,7 @@ void ProgramWindow::stepProgram(const double &dt, const bool &reverse)
 
 void ProgramWindow::animateBeginEvent(sofa::simulation::Node *groot)
 {
-    if (m_isDrivingSimulation)
+    if (isDrivingSimulation())
     {
         if (m_program.isEmpty())
             return;
@@ -962,7 +962,7 @@ void ProgramWindow::animateBeginEvent(sofa::simulation::Node *groot)
 void ProgramWindow::animateEndEvent(sofa::simulation::Node *groot)
 {
     SOFA_UNUSED(groot);
-    if (m_isDrivingSimulation)
+    if (isDrivingSimulation())
         groot->setTime(m_time);
 }
 
@@ -973,15 +973,10 @@ void ProgramWindow::setIPController(models::IPController::SPtr IPController)
         m_program = models::Program(IPController);
 }
 
-void ProgramWindow::setDrivingTCPTarget(const bool &isDrivingSimulation)
-{
-    m_isDrivingSimulation=isDrivingSimulation;
-}
-
 void ProgramWindow::addStartMoveBlockMenu(const std::string& menuLabel,
-                                      const sofa::Index& trackIndex,
-                                      std::shared_ptr<models::Track> track,
-                                      std::shared_ptr<models::actions::StartMove> startmove)
+                                        const sofa::Index& trackIndex,
+                                        std::shared_ptr<models::Track> track,
+                                        std::shared_ptr<models::actions::StartMove> startmove)
 {
     if (ImGui::BeginPopup(menuLabel.c_str()))
     {

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.h
@@ -21,11 +21,11 @@
  ******************************************************************************/
 #pragma once
 
-#include <filesystem>
 #include <imgui.h>
 
 #include <SofaImGui/windows/BaseWindow.h>
 #include <SofaImGui/Workbench.h>
+#include <SofaImGui/DrivingWindow.h>
 #include <SofaImGui/models/Program.h>
 
 #include <SofaImGui/models/IPController.h>
@@ -56,7 +56,6 @@ class SOFAIMGUI_API ProgramWindow : public BaseWindow
 
     void setTime(const double &time) {m_time=time;}
     void setIPController(models::IPController::SPtr IPController);
-    void setDrivingTCPTarget(const bool &isDrivingSimulation) override;
 
     void importProgram();
     bool importProgram(const std::string& filename);
@@ -132,6 +131,8 @@ class SOFAIMGUI_API ProgramWindow : public BaseWindow
 
     void saveProgramDirAndFilename(const std::string& filename);
     void loadAndProcessWindowSettings();
+
+    bool isDrivingSimulation() {return drivingWindow == DrivingWindow::PROGRAM;}
 
 };
 

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -88,24 +88,6 @@ void ViewportWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI,
                 {
                     addStateWindow(baseGUI, windowFlags);
                     addSimulationTimeAndFPS(groot);
-
-                    // Panel backgroung
-                    ImDrawList* drawList = ImGui::GetWindowDrawList();
-                    ImVec2 size(ImGui::GetFrameHeight() * 2 + ImGui::GetStyle().ItemSpacing.x * 4 + m_maxPanelItemWidth, ImGui::GetFrameHeight() + ImGui::GetStyle().FramePadding.y * 2);
-
-                    float x = ImGui::GetWindowPos().x + ImGui::GetWindowWidth() / 2.f - ImGui::GetFrameHeight() * 4.f + ImGui::GetStyle().FramePadding.x;
-                    float y = ImGui::GetWindowPos().y + ImGui::GetStyle().FramePadding.y;
-
-                    ImRect bb(ImVec2(x, y), ImVec2(x + size.x, y + size.y));
-
-                    { // Draw
-                        auto color = ImGui::GetStyle().Colors[ImGuiCol_TabActive];
-                        color.w = 0.6f;
-                        drawList->AddRectFilled(bb.Min, bb.Max,
-                                                ImGui::GetColorU32(color),
-                                                ImGui::GetStyle().FrameRounding,
-                                                ImDrawFlags_None);
-                    }
                 }
 
                 addCameraButtons(baseGUI, groot);
@@ -167,8 +149,8 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     double orientationGizmoSize = frameGizmoSize;
     bool axisClicked[3]{false};
     ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0, 0, 0, 0));
-    if (ImGui::Begin("ViewportChildGizmos", &m_isOpen, ImGuiWindowFlags_ChildWindow |
-                    ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
+    if (ImGui::Begin("ViewportChildGizmos", &m_isOpen, ImGuiWindowFlags_ChildWindow| ImGuiWindowFlags_AlwaysAutoResize |
+                                                        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
     {
         ImRect wosize = ImRect(wpos, ImVec2(wpos.x + frameGizmoSize + orientationGizmoEnabled * orientationGizmoSize, wpos.y + frameGizmoSize));
         ImGui::ItemSize(wosize);
@@ -251,8 +233,8 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     // Buttons
     ImVec2 buttonSize = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
     bool translate = false;
-    if (ImGui::Begin("ViewportChildLeftButtons", &m_isOpen, ImGuiWindowFlags_ChildWindow |
-                     ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
+    if (ImGui::Begin("ViewportChildLeftButtons", &m_isOpen, ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_AlwaysAutoResize |
+                                                            ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
     {
         ImGui::TextDisabled("  " ICON_FA_VIDEO);
 
@@ -486,6 +468,52 @@ void ViewportWindow::addContextMenu(const ImTextureID& texture)
     }
 }
 
+bool ViewportWindow::addAnimateButton(bool *animate, const float &shift_x)
+{
+    ImVec2 buttonSize = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
+    bool isItemClicked = false;
+
+    if (m_isOpen)
+    {
+        if (ImGui::Begin(getLabel().c_str(), &m_isOpen))
+        {
+            auto position = ImGui::GetWindowPos();
+            position.x += ImGui::GetWindowWidth() * 0.5f - shift_x;
+            position.y += ImGui::GetStyle().FramePadding.y;
+            ImGui::SetNextWindowPos(position);  // attach the button window to top middle of the viewport window
+
+            // Middle buttons background
+            // Clip down
+            auto color = ImGui::GetStyle().Colors[ImGuiCol_TabActive];
+            color.w = 0.6f;
+            ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1); // Work around to add padding
+            ImGui::PushStyleColor(ImGuiCol_ChildBg, ImGui::GetColorU32(color));
+            ImGui::PushStyleColor(ImGuiCol_Border, ImGui::GetColorU32(color));
+
+            if (ImGui::Begin("ViewportChildMiddleButtons", &m_isOpen, ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_AlwaysAutoResize |
+                                                                      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
+            {
+                // ImGui::SameLine();
+                ImGui::Button(*animate ? ICON_FA_PAUSE : ICON_FA_PLAY, buttonSize);
+                ImGui::SetItemTooltip(*animate ? "Stop simulation" : "Start simulation");
+
+                if (ImGui::IsItemClicked())
+                {
+                    *animate = !*animate;
+                    isItemClicked = true;
+                }
+            }
+            ImGui::EndChild();
+
+            ImGui::PopStyleColor(2);
+            ImGui::PopStyleVar();
+        }
+        ImGui::End();
+    }
+
+    return isItemClicked;
+}
+
 bool ViewportWindow::addStepButton()
 {
     ImVec2 buttonSize = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
@@ -495,71 +523,17 @@ bool ViewportWindow::addStepButton()
     {
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen))
         {
-            if(ImGui::BeginChild("Render"))
+            if (ImGui::Begin("ViewportChildMiddleButtons", &m_isOpen, ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_AlwaysAutoResize |
+                                                                    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
             {
-                auto position = ImGui::GetWindowPos();
-                position.x += ImGui::GetWindowWidth() / 2 - ImGui::GetFrameHeight() * 4.f;
-                position.y += ImGui::GetStyle().FramePadding.y;
-                ImGui::SetNextWindowPos(position);  // attach the button window to top middle of the viewport window
-
-                ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-                if (ImGui::Begin("ViewportChildButtons", &m_isOpen,
-                                 ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
-                {
-                    ImGui::SameLine();
-                    ImGui::PushItemFlag(ImGuiItemFlags_ButtonRepeat, true);
-                    if (ImGui::Button(ICON_FA_FORWARD_STEP, buttonSize))
-                        isItemClicked = true;
-                    ImGui::PopItemFlag();
-                    ImGui::SetItemTooltip("One step of simulation");
-                }
-                ImGui::End();
-                ImGui::PopStyleColor();
-                ImGui::EndChild();
+                ImGui::SameLine();
+                ImGui::PushItemFlag(ImGuiItemFlags_ButtonRepeat, true);
+                if (ImGui::Button(ICON_FA_FORWARD_STEP, buttonSize))
+                    isItemClicked = true;
+                ImGui::PopItemFlag();
+                ImGui::SetItemTooltip("One step of simulation");
             }
-        }
-        ImGui::End();
-    }
-
-    return isItemClicked;
-}
-
-bool ViewportWindow::addAnimateButton(bool *animate)
-{
-    ImVec2 buttonSize = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
-    bool isItemClicked = false;
-    
-    if (m_isOpen)
-    {
-        if (ImGui::Begin(getLabel().c_str(), &m_isOpen))
-        {
-            if(ImGui::BeginChild("Render"))
-            {
-                auto position = ImGui::GetWindowPos();
-                position.x += ImGui::GetWindowWidth() / 2.f - ImGui::GetFrameHeight() * 4.f;
-                position.y += ImGui::GetStyle().FramePadding.y;
-                ImGui::SetNextWindowPos(position);  // attach the button window to top middle of the viewport window
-
-                ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-                if (ImGui::Begin("ViewportChildButtons", &m_isOpen,
-                         ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
-                {
-                    ImGui::SameLine();
-                    ImGui::Button(*animate ? ICON_FA_PAUSE : ICON_FA_PLAY, buttonSize);
-                    ImGui::SetItemTooltip(*animate ? "Stop simulation" : "Start simulation");
-
-                    if (ImGui::IsItemClicked())
-                    {
-                        *animate = !*animate;
-                        isItemClicked = true;
-                    }
-
-                }
-                ImGui::End();
-                ImGui::PopStyleColor();
-
-                ImGui::EndChild();
-            }
+            ImGui::EndChild();
         }
         ImGui::End();
     }
@@ -575,33 +549,20 @@ bool ViewportWindow::addDrivingTabCombo(int *mode, const char *listModes[], cons
     {
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen))
         {
-            if(ImGui::BeginChild("Render"))
+            if (ImGui::Begin("ViewportChildMiddleButtons", &m_isOpen, ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_AlwaysAutoResize |
+                                                                      ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
             {
-                auto position = ImGui::GetWindowPos();
-                position.x += ImGui::GetWindowWidth() / 2.f - ImGui::GetFrameHeight() * 4.f;
-                position.y += ImGui::GetStyle().FramePadding.y;
-                ImGui::SetNextWindowPos(position);  // attach the button window to top middle of the viewport window
-
-                ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-                if (ImGui::Begin("ViewportChildButtons", &m_isOpen,
-                                 ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
-                {
-                    ImGui::SameLine();
-                    ImGui::PushItemWidth(m_maxPanelItemWidth);
-                    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.53f, 0.54f, 0.55f, 1.00f));
-                    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.53f, 0.54f, 0.55f, 1.00f));
-                    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.53f, 0.54f, 0.55f, 1.00f));
-                    hasValueChanged = ImGui::Combo("##DrivingWindowViewport", mode, listModes, sizeListModes);
-                    ImGui::PopStyleColor(3);
-                    ImGui::PopItemWidth();
-                    ImGui::SetItemTooltip("Choose a window to drive the TCP target");
-
-                }
-                ImGui::End();
-                ImGui::PopStyleColor();
-
-                ImGui::EndChild();
+                ImGui::SameLine();
+                ImGui::PushItemWidth(m_maxPanelItemWidth);
+                ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.53f, 0.54f, 0.55f, 1.00f));
+                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.53f, 0.54f, 0.55f, 1.00f));
+                ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.53f, 0.54f, 0.55f, 1.00f));
+                hasValueChanged = ImGui::Combo("##DrivingWindowViewport", mode, listModes, sizeListModes);
+                ImGui::PopStyleColor(3);
+                ImGui::PopItemWidth();
+                ImGui::SetItemTooltip("Choose a window to drive the TCP target");
             }
+            ImGui::EndChild();
         }
         ImGui::End();
     }


### PR DESCRIPTION
**In this PR**:

- Adds `drivingWindow` singleton
- Viewport: cleaning `ChildWindow` of middle buttons 
- Allow to set `None` driving window: you can drive the simulation from a python script (`Controller`)
- Don't show the DrivingWindow ComboBox if no robot in the simulation (**not sure about this one**) 

<img width="2592" height="1376" alt="image" src="https://github.com/user-attachments/assets/1f89fd2d-1a2c-4040-ac16-52a928a16c2d" />

<img width="2597" height="1294" alt="image" src="https://github.com/user-attachments/assets/a2ba1d6d-ca64-4484-aebb-f75fae5654e3" />