### PR TITLE
[FooterStatusBar] Allow to add link in footer message

### DIFF
--- a/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
+++ b/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
  *                 SOFA, Simulation Open-Framework Architecture                *
  *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
  *                                                                             *
@@ -26,6 +26,8 @@
 #include <sofa/helper/logging/Messaging.h>
 #include <SofaImGui/FooterStatusBar.h>
 #include <sofa/version.h>
+
+#include <filesystem>
 
 namespace sofaimgui {
 
@@ -83,39 +85,40 @@ void FooterStatusBar::showTempMessageOnStatusBar()
                 {
                     m_tempMessage.clear();
                     m_tempMessagePath.clear();
-                    return;
                 }
-
-                float length = ImGui::CalcTextSize((m_tempMessage + m_tempMessagePath).c_str()).x;
-                float center = (ImGui::GetWindowWidth() - length) * 0.5f;
-                ImGui::SetCursorPosX(center); // Set the position to the middle of the status bar
-
-                std::string icon;
-                switch (m_tempMessageType) {
-                case MessageType::MWARNING:
+                else 
                 {
-                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.9f, 0.4f, 0.f, 1.f));
-                    icon = ICON_FA_CIRCLE_EXCLAMATION;
-                    break;
-                }
-                case MessageType::MERROR:
-                {
-                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.9f, 0.f, 0.f, 1.f));
-                    icon = ICON_FA_CIRCLE_EXCLAMATION;
-                    break;
-                }
-                default:
-                {
-                    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_Text));
-                    icon = ICON_FA_CIRCLE_INFO;
-                    break;
-                }
-                }
-                ImGui::Text("%s", (icon + " " + m_tempMessage).c_str());
+                    float length = ImGui::CalcTextSize((m_tempMessage + m_tempMessagePath).c_str()).x;
+                    float center = (ImGui::GetWindowWidth() - length) * 0.5f;
+                    ImGui::SetCursorPosX(center); // Set the position to the middle of the status bar
 
-                showPath();
+                    std::string icon;
+                    switch (m_tempMessageType) {
+                    case MessageType::MWARNING:
+                    {
+                        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.9f, 0.4f, 0.f, 1.f));
+                        icon = ICON_FA_CIRCLE_EXCLAMATION;
+                        break;
+                    }
+                    case MessageType::MERROR:
+                    {
+                        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.9f, 0.f, 0.f, 1.f));
+                        icon = ICON_FA_CIRCLE_EXCLAMATION;
+                        break;
+                    }
+                    default:
+                    {
+                        ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_Text));
+                        icon = ICON_FA_CIRCLE_INFO;
+                        break;
+                    }
+                    }
+                    ImGui::Text("%s", (icon + " " + m_tempMessage).c_str());
 
-                ImGui::PopStyleColor();
+                    showPath();
+
+                    ImGui::PopStyleColor();
+                }
             }
 
             ImGui::EndMenuBar();
@@ -136,7 +139,7 @@ void FooterStatusBar::showPath()
             ImGui::TextLink(m_tempMessagePath.c_str());
             if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
             {
-                if (sofa::helper::system::FileSystem::isFile(m_tempMessagePath, true))
+                if (sofa::helper::system::FileSystem::isFile(m_tempMessagePath, true) && std::filesystem::path(m_tempMessagePath).has_parent_path())
                 {
                     ImGui::OpenPopup(m_fileToOpenPopUpLabel.c_str());
                 }
@@ -164,12 +167,15 @@ void FooterStatusBar::showFilePopUpModal()
         ImGui::NewLine();
 
         if (ImGui::Button("Open File"))
+        {
             sofa::helper::system::FileSystem::openFileWithDefaultApplication(m_fileToOpen);
+            ImGui::CloseCurrentPopup();
+        }
         ImGui::SameLine();
         if (ImGui::Button("Open File Location"))
         {
-            auto location = sofa::helper::system::FileSystem::getParentDirectory(m_fileToOpen);
-            sofa::helper::system::FileSystem::openFileWithDefaultApplication(location);
+            sofa::helper::system::FileSystem::openFileWithDefaultApplication(std::filesystem::path(m_fileToOpen).parent_path().string());
+            ImGui::CloseCurrentPopup();
         }
         ImGui::SameLine();
         if (ImGui::Button("Cancel"))

--- a/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
+++ b/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
@@ -19,8 +19,10 @@
  *                                                                             *
  * Contact information: contact@sofa-framework.org                             *
  ******************************************************************************/
-#include "IconsFontAwesome6.h"
-#include "imgui_internal.h"
+#include <IconsFontAwesome6.h>
+#include <SofaImGui/widgets/Widgets.h>
+#include <imgui_internal.h>
+#include <sofa/helper/system/FileSystem.h>
 #include <sofa/helper/logging/Messaging.h>
 #include <SofaImGui/FooterStatusBar.h>
 #include <sofa/version.h>
@@ -61,26 +63,30 @@ void FooterStatusBar::showFooterStatusBar()
 void FooterStatusBar::showTempMessageOnStatusBar()
 {
     static float infoRefreshTime = 0.;
+    float messageLifeSpan = m_tempMessagePath.empty()? m_tempMessageLifeSpan: m_tempMessageLifeSpan*2.;
 
-    if (!m_tempMessage.empty())
+    if (ImGui::Begin("##FooterStatusBar"))
     {
-        if (m_refreshTempMessage)
+        if (ImGui::BeginMenuBar())
         {
-            infoRefreshTime = (float)ImGui::GetTime();
-            m_refreshTempMessage = false;
-        }
-        
-        if((float)ImGui::GetTime() - infoRefreshTime > m_tempMessageLifeSpan)
-        {
-            m_tempMessage.clear();
-            return;
-        }
+            showFilePopUpModal();
 
-        if (ImGui::Begin("##FooterStatusBar"))
-        {
-            if (ImGui::BeginMenuBar())
+            if (!m_tempMessage.empty())
             {
-                float length = ImGui::CalcTextSize(m_tempMessage.c_str()).x;
+                if (m_refreshTempMessage)
+                {
+                    infoRefreshTime = (float)ImGui::GetTime();
+                    m_refreshTempMessage = false;
+                }
+
+                if((float)ImGui::GetTime() - infoRefreshTime > messageLifeSpan)
+                {
+                    m_tempMessage.clear();
+                    m_tempMessagePath.clear();
+                    return;
+                }
+
+                float length = ImGui::CalcTextSize((m_tempMessage + m_tempMessagePath).c_str()).x;
                 float center = (ImGui::GetWindowWidth() - length) * 0.5f;
                 ImGui::SetCursorPosX(center); // Set the position to the middle of the status bar
 
@@ -106,20 +112,79 @@ void FooterStatusBar::showTempMessageOnStatusBar()
                 }
                 }
                 ImGui::Text("%s", (icon + " " + m_tempMessage).c_str());
-                ImGui::PopStyleColor();
 
-                ImGui::EndMenuBar();
+                showPath();
+
+                ImGui::PopStyleColor();
+            }
+
+            ImGui::EndMenuBar();
+        }
+    }
+    ImGui::End();
+}
+
+void FooterStatusBar::showPath()
+{
+    if (!m_tempMessagePath.empty())
+    {
+        m_fileToOpen = m_tempMessagePath;
+        ImGui::SameLine(0., ImGui::GetStyle().FramePadding.x);
+
+        if (sofa::helper::system::FileSystem::exists(m_tempMessagePath, true))
+        {
+            ImGui::TextLink(m_tempMessagePath.c_str());
+            if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+            {
+                if (sofa::helper::system::FileSystem::isFile(m_tempMessagePath, true))
+                {
+                    ImGui::OpenPopup(m_fileToOpenPopUpLabel.c_str());
+                }
+                else
+                    sofa::helper::system::FileSystem::openFileWithDefaultApplication(m_tempMessagePath);
             }
         }
-        ImGui::End();
+        else if (m_tempMessagePath.starts_with("http"))
+        {
+            ImGui::LocalTextLinkOpenURL(m_tempMessagePath.c_str(), m_tempMessagePath.c_str());
+        }
+        else
+        {
+            ImGui::Text("%s", m_tempMessagePath.c_str());
+        }
     }
 }
 
-void FooterStatusBar::setTempMessage(const std::string &message, const MessageType& type)
+void FooterStatusBar::showFilePopUpModal()
+{
+    if (ImGui::BeginPopupModal(m_fileToOpenPopUpLabel.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        ImGui::NewLine();
+        ImGui::Text("Path: %s", m_fileToOpen.c_str());
+        ImGui::NewLine();
+
+        if (ImGui::Button("Open File"))
+            sofa::helper::system::FileSystem::openFileWithDefaultApplication(m_fileToOpen);
+        ImGui::SameLine();
+        if (ImGui::Button("Open File Location"))
+        {
+            auto location = sofa::helper::system::FileSystem::getParentDirectory(m_fileToOpen);
+            sofa::helper::system::FileSystem::openFileWithDefaultApplication(location);
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel"))
+            ImGui::CloseCurrentPopup();
+
+        ImGui::EndPopup();
+    }
+}
+
+void FooterStatusBar::setTempMessage(const std::string &message, const MessageType& type, const std::string &path)
 {
     m_refreshTempMessage = true;
     m_tempMessageType = type;
     m_tempMessage = message;
+    m_tempMessagePath = path;
     std::string from = "GUI";
 
     switch (type) {

--- a/SofaImGui/src/SofaImGui/FooterStatusBar.h
+++ b/SofaImGui/src/SofaImGui/FooterStatusBar.h
@@ -36,14 +36,21 @@ public:
 
     void showFooterStatusBar();
     void showTempMessageOnStatusBar(); /// Show temporary info message in the middle of the status bar.
-    void setTempMessage(const std::string &message, const MessageType &type=MessageType::MINFO); /// Set the temporary info message
+    void setTempMessage(const std::string &message, const MessageType &type=MessageType::MINFO, const std::string &path=""); /// Set the temporary info message
 
 protected:
 
+    void showPath();
+    void showFilePopUpModal();
+
     std::string m_tempMessage;
+    std::string m_tempMessagePath;
     MessageType m_tempMessageType;
     bool m_refreshTempMessage;
     float m_tempMessageLifeSpan{6.}; /// Life span of the temporary message, in seconds
+
+    std::string m_fileToOpen;
+    std::string m_fileToOpenPopUpLabel{"Open##FiletoTopen"};
 
 };
 

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
  *                 SOFA, Simulation Open-Framework Architecture                *
  *                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
  *                                                                             *
@@ -800,7 +800,8 @@ void ProgramWindow::importProgram()
 
     if (successfulImport)
     {
-        FooterStatusBar::getInstance().setTempMessage("Imported program [" + path.string() + "]");
+        //FooterStatusBar::getInstance().setTempMessage("Imported program [" + path.string() + "]");
+        FooterStatusBar::getInstance().setTempMessage("Imported program [" + path.string() + "]", FooterStatusBar::MINFO, path.string());
     }
 }
 

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
@@ -800,8 +800,7 @@ void ProgramWindow::importProgram()
 
     if (successfulImport)
     {
-        //FooterStatusBar::getInstance().setTempMessage("Imported program [" + path.string() + "]");
-        FooterStatusBar::getInstance().setTempMessage("Imported program [" + path.string() + "]", FooterStatusBar::MINFO, path.string());
+        FooterStatusBar::getInstance().setTempMessage("Imported program [" + path.string() + "]");
     }
 }
 


### PR DESCRIPTION
In this PR:

- add path option to `setTempMessage`
- handles three cases:
    - **file** : opens a modal window to choose between opening the file or location
    - **path** : opens the location
    - **url** : opens in web browser

Useful for instance for the [video recorder](https://github.com/SofaComplianceRobotics/SofaGLFW/pull/108).

<img width="3836" height="2232" alt="image" src="https://github.com/user-attachments/assets/56922dde-e68b-49ae-8585-b0fc60db349f" />
<img width="3836" height="2232" alt="image" src="https://github.com/user-attachments/assets/90d1db0c-63da-42f6-8bd4-174b1d0c0cf5" />
