### PR TITLE
[SofaGLFW] Introducing the tag 'createdByGUI'

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -133,9 +133,10 @@ public:
         }
     }
 
-    const char* getGUINodeName() {
-        return "GUI";
-    }
+
+    const char* getGUINodeName() {return "GUI";}
+    sofa::core::objectmodel::Tag getGUITag() {return sofa::core::objectmodel::Tag("createdByGUI");}
+
 
 private:
     // GLFW callbacks

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -952,7 +952,7 @@ void ImGuiGUIEngine::createGUINode()
             guinode = root->createChild(nodeName);
         }
         guinode->addTag(sofa::core::objectmodel::Tag("NoBBox"));
-        guinode->addTag(sofa::core::objectmodel::Tag("createdByGUI"));
+        guinode->addTag(m_baseGUI->getGUITag());
         guinode->f_bbox.setParent(&root->f_bbox);
     }
 }

--- a/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
+++ b/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
@@ -126,7 +126,7 @@ void ViewMenu::showGrid(const bool& show, const float& squareSize, const float& 
                 auto newGrid = sofa::core::objectmodel::New<sofa::component::visual::VisualGrid>();
                 guiNode->addObject(newGrid);
                 newGrid->setName(name);
-                newGrid->addTag(sofa::core::objectmodel::Tag("createdByGUI"));
+                newGrid->addTag(m_baseGUI->getGUITag());
                 newGrid->d_enable.setValue(show);
                 newGrid->d_size.setValue(gridSize);
                 newGrid->d_thickness.setValue(thickness);
@@ -158,7 +158,7 @@ void ViewMenu::showOriginFrame(const bool& show)
                 auto newOriginFrame = sofa::core::objectmodel::New<sofa::component::visual::LineAxis>();
                 guiNode->addObject(newOriginFrame);
                 newOriginFrame->setName("ViewportOriginFrame");
-                newOriginFrame->addTag(sofa::core::objectmodel::Tag("createdByGUI"));
+                newOriginFrame->addTag(m_baseGUI->getGUITag());
                 newOriginFrame->d_enable.setValue(show);
                 newOriginFrame->d_infinite.setValue(true);
                 newOriginFrame->d_thickness.setValue(2.f);


### PR DESCRIPTION
This tag will be used later to:
- hide those nodes/components from the Scene Graph view in the Scene Editor workbench
- display the information in the other workbenches