### PR TITLE
[Windows] Fixes widget size based on content region available

### DIFF
--- a/SofaImGui/src/SofaImGui/windows/IOWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/IOWindow.cpp
@@ -112,8 +112,6 @@ void IOWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWindowF
                 ImGui::BeginDisabled();
             }
 
-            m_itemWidth = ImGui::GetWindowWidth() - ImGui::GetStyle().WindowPadding.x * 4;
-
             static const char* items[]{
 #if SOFAIMGUI_WITH_ROS
                                        "ROS",
@@ -124,7 +122,7 @@ void IOWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWindowF
             ImGui::Spacing();
             ImGui::Indent();
             ImGui::Text("Method:");
-            ImGui::PushItemWidth(m_itemWidth);
+            ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
             ImGui::LocalCombo("##ComboMethod", &m_method, items, IM_ARRAYSIZE(items));
             ImGui::PopItemWidth();
             ImGui::Spacing();
@@ -256,7 +254,7 @@ void IOWindow::showROSOutput()
         static bool validNodeName = true;
         static char nodeBuf[30];
 
-        ImGui::PushItemWidth(m_itemWidth);
+        ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
         ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
         bool hasNodeNameChanged = ImGui::InputTextWithHint("##NodePublishers", "Enter a node name", nodeBuf, 30, ImGuiInputTextFlags_CharsNoBlank);
         ImGui::PopStyleVar();
@@ -301,7 +299,7 @@ void IOWindow::showROSOutput()
         ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
 
         bool updateROSData = false;
-        if (ImGui::BeginListBox("##StatePublish", ImVec2(m_itemWidth, 0)))
+        if (ImGui::BeginListBox("##StatePublish", ImVec2(ImGui::GetContentRegionAvail().x, 0)))
         {
             // Simulation data
             for (const auto& [key, value] : m_IOData)
@@ -401,7 +399,7 @@ void IOWindow::showROSInput()
         nodes.push_back(nodelist[i].c_str());
 
     ImGui::Text("Select a node:");
-    ImGui::PushItemWidth(m_itemWidth);
+    ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
     ImGui::LocalCombo("##NodeSubscription", &nodeID, nodes.data(), nbNodes);
     ImGui::PopItemWidth();
 
@@ -438,7 +436,7 @@ void IOWindow::showROSInput()
         ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
 
         bool updateROSData = false;
-        if (ImGui::BeginListBox("##StateSubscription", ImVec2(m_itemWidth, 0)))
+        if (ImGui::BeginListBox("##StateSubscription", ImVec2(ImGui::GetContentRegionAvail().x, 0)))
         {
             // TCP target
             for (const auto& [simStateName, stateValue] : m_IOData)

--- a/SofaImGui/src/SofaImGui/windows/IOWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/IOWindow.h
@@ -189,8 +189,6 @@ class SOFAIMGUI_API IOWindow : public BaseWindow
     std::vector<models::SimulationState::StateData> m_simulationStateData; // user defined output
     std::map<std::string, sofa::core::BaseData*> m_subscribableData; // user defined input
 
-    float m_itemWidth;
-
 #if SOFAIMGUI_WITH_ROS
     std::shared_ptr<ROSNode> m_rosnode;
 

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
@@ -335,8 +335,8 @@ bool MoveWindow::showSliderDouble(const char* name, const char* label1, const ch
     ImGui::AlignTextToFramePadding();
     ImGui::Text("%s", name);
     ImGui::SameLine();
-    float inputWidth = ImGui::CalcTextSize("-100000,00").x + ImGui::GetFrameHeight() / 2 + ImGui::GetStyle().ItemSpacing.x * 2;
-    float sliderWidth = ImGui::GetWindowWidth() - inputWidth - ImGui::CalcTextSize(name).x - ImGui::GetStyle().FramePadding.x * 3 - ImGui::GetStyle().IndentSpacing - ImGui::GetStyle().ScrollbarSize;
+    float inputWidth = ImGui::CalcTextSize("-100000,00").x + ImGui::GetFrameHeight() / 2 + ImGui::GetStyle().FramePadding.x;
+    float sliderWidth = ImGui::GetContentRegionAvail().x - inputWidth;
 
     ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetColorU32(ImGuiCol_TextDisabled));
     ImGui::PushItemWidth(sliderWidth);

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
@@ -174,7 +174,7 @@ void MyRobotWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWi
                         if(connected)
                             ImGui::BeginDisabled();
 
-                        ImGui::PushItemWidth(ImGui::GetWindowWidth() - ImGui::GetStyle().WindowPadding.x * 4);
+                        ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x);
                         const size_t nbPorts = m_connection.ports.size();
                         std::vector<const char*> ports;
                         ports.reserve(nbPorts);
@@ -195,7 +195,7 @@ void MyRobotWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWi
                         ImGui::Text("Status:");
                         ImGui::SameLine();
 
-                        ImGui::PushStyleColor(ImGuiCol_Text, (connected)? ImColor(COLOR_GREEN).Value: ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled)); // TODO : color utils
+                        ImGui::PushStyleColor(ImGuiCol_Text, (connected)? ImColor(COLOR_GREEN).Value: ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
                         ImGui::Text((connected)? "Connected": "Disconnected");
                         ImGui::PopStyleColor();
 
@@ -282,7 +282,7 @@ void MyRobotWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWi
                                 for (size_t i=0; i<typeinfo->size(); i++)
                                 {
                                     setting.buffer = typeinfo->getScalarValue(values, i);
-                                    showSliderDouble(setting.description, &setting.buffer, setting.min, setting.max, (isInEmptyGroup(group.description))? 1: 2);
+                                    showSliderDouble(setting.description, &setting.buffer, setting.min, setting.max);
                                     setting.buffer = std::clamp(setting.buffer, setting.min, setting.max);
                                     uiValue += std::to_string(setting.buffer) + " ";
                                 }
@@ -310,11 +310,11 @@ void MyRobotWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWi
     }
 }
 
-bool MyRobotWindow::showSliderDouble(const std::string& name, double* v, const double& min, const double& max, const int nbIndents)
+bool MyRobotWindow::showSliderDouble(const std::string& name, double* v, const double& min, const double& max)
 {
     bool hasValueChanged = false;
-    float inputWidth = ImGui::CalcTextSize("-100000,00").x + ImGui::GetFrameHeight() / 2 + ImGui::GetStyle().ItemSpacing.x * 2;
-    float sliderWidth = ImGui::GetWindowWidth() - inputWidth - ImGui::CalcTextSize(name.c_str()).x - ImGui::GetStyle().FramePadding.x - ImGui::GetStyle().IndentSpacing * nbIndents - ImGui::GetStyle().ScrollbarSize;
+    float inputWidth = ImGui::CalcTextSize("-100000,00").x + ImGui::GetFrameHeight() / 2 + ImGui::GetStyle().FramePadding.x;
+    float sliderWidth = ImGui::GetContentRegionAvail().x - inputWidth;
 
     ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetColorU32(ImGuiCol_TextDisabled));
     ImGui::PushItemWidth(sliderWidth);

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.h
@@ -82,7 +82,7 @@ class SOFAIMGUI_API MyRobotWindow : public BaseWindow
     bool enabled() override;
 
     bool isInEmptyGroup(const std::string &group);
-    bool showSliderDouble(const std::string &name, double* v, const double& min, const double& max, const int nbIndents);
+    bool showSliderDouble(const std::string &name, double* v, const double& min, const double& max);
 };
 
 }


### PR DESCRIPTION
Recently discovered the method `ImGui::GetContentRegionAvail()`...
Use it to fix widget size issues. 

**Before/After: IOWindow**

<img width="100%" alt="Screenshot from 2026-04-27 14-10-44" src="https://github.com/user-attachments/assets/ac44897e-3069-4594-8e68-dee7bc20a285" />

<img width="100%" alt="Screenshot from 2026-04-27 14-23-11" src="https://github.com/user-attachments/assets/769dbfe0-bbbc-480b-b431-4364eaf86575" />


**Before/After: MoveWindow & MyRobotWindow**

<img width="100%" alt="Screenshot from 2026-04-27 14-04-17" src="https://github.com/user-attachments/assets/1bd65338-95a2-44bf-94f6-3066261618a9" />

<img width="100%" alt="Screenshot from 2026-04-27 14-22-59" src="https://github.com/user-attachments/assets/5d59e8eb-e58b-4a4c-aafe-72b75d0612fd" />
