### PR TITLE
[widgets] adds RigidDeriv widget and remove label

### DIFF
--- a/SofaImGui/src/SofaImGui/widgets/ImGuiDataWidget.cpp
+++ b/SofaImGui/src/SofaImGui/widgets/ImGuiDataWidget.cpp
@@ -51,14 +51,13 @@ void DataWidget<std::string>::showWidget(MyData& data)
 {
     const std::string initialValue = data.getValue();
     std::string changeableValue = initialValue;
-    const auto& label = data.getName();
     const auto id = data.getName() + data.getOwner()->getPathName();
 
     bool disable = data.getName() == "name";
     if (disable)
         ImGui::BeginDisabled();
 
-    if (ImGui::InputText((label + "##" + id).c_str(), &changeableValue))
+    if (ImGui::InputText(("##" + id).c_str(), &changeableValue))
         data.setValue(changeableValue);
 
     if (disable)
@@ -70,10 +69,9 @@ void DataWidget<bool>::showWidget(MyData& data)
 {
     const bool initialValue = data.getValue();
     bool changeableValue = initialValue;
-    const auto& label = data.getName();
-    const auto id = data.getName() + data.getOwner()->getPathName();
+    const auto id = data.getName() + (data.getOwner() ? data.getOwner()->getPathName() : "");
 
-    ImGui::LocalCheckBox((label + "##" + id).c_str(), &changeableValue);
+    ImGui::LocalCheckBox(("##" + id).c_str(), &changeableValue);
     if (changeableValue != initialValue)
     {
         data.setValue(changeableValue);
@@ -155,7 +153,9 @@ void showWidgetT(Data<sofa::type::Vec<N, ValueType> >& data)
         {
             ImGui::TableNextColumn();
             ImGui::PushID(i);
-            showScalarWidget("", ImGui::TableGetColumnName(i++), v);
+            ImGui::PushItemWidth(-1); // Fit container width
+            showScalarWidget(ImGui::TableGetColumnName(i++), v);
+            ImGui::PopItemWidth();
             ImGui::PopID();
         }
 
@@ -304,6 +304,34 @@ void DataWidget<sofa::type::vector<sofa::defaulttype::RigidCoord<2, float> > >::
 }
 
 /***********************************************************************************************************************
+ * Vectors of RigidDeriv
+ **********************************************************************************************************************/
+
+template<>
+void DataWidget<sofa::type::vector<sofa::defaulttype::RigidDeriv<3, double> > >::showWidget(MyData& data)
+{
+    showWidgetT(data);
+}
+
+template<>
+void DataWidget<sofa::type::vector<sofa::defaulttype::RigidDeriv<3, float> > >::showWidget(MyData& data)
+{
+    showWidgetT(data);
+}
+
+template<>
+void DataWidget<sofa::type::vector<sofa::defaulttype::RigidDeriv<2, double> > >::showWidget(MyData& data)
+{
+    showWidgetT(data);
+}
+
+template<>
+void DataWidget<sofa::type::vector<sofa::defaulttype::RigidDeriv<2, float> > >::showWidget(MyData& data)
+{
+    showWidgetT(data);
+}
+
+/***********************************************************************************************************************
  * Topology elements
  **********************************************************************************************************************/
 
@@ -431,9 +459,7 @@ void DataWidget<std::map<std::string, sofa::type::vector<float> > >::showWidget(
 template<>
 void DataWidget<helper::OptionsGroup>::showWidget(MyData& data)
 {
-    const auto& label = data.getName();
-    const auto id = data.getName() + data.getOwner()->getPathName();
-
+    const auto id = data.getName() + (data.getOwner() ? data.getOwner()->getPathName() : "");
     const auto& optionsGroup = data.getValue();
     int selectedOption = static_cast<int>(optionsGroup.getSelectedId());
 
@@ -443,7 +469,7 @@ void DataWidget<helper::OptionsGroup>::showWidget(MyData& data)
         charArray[i] = optionsGroup[i].c_str();
     }
 
-    if (ImGui::Combo((label + "##" + id).c_str(), &selectedOption, charArray.get(), static_cast<int>(optionsGroup.size())))
+    if (ImGui::Combo(("##" + id).c_str(), &selectedOption, charArray.get(), static_cast<int>(optionsGroup.size())))
     {
         helper::WriteAccessor(data)->setSelectedItem(selectedOption);
     }
@@ -456,9 +482,7 @@ template<>
 void DataWidget<helper::BaseSelectableItem>::showWidget(
     sofa::core::objectmodel::BaseData& data, const helper::BaseSelectableItem* selectableItems)
 {
-    const auto& label = data.getName();
-    const auto id = data.getName() + data.getOwner()->getPathName();
-
+    const auto id = data.getName() + (data.getOwner() ? data.getOwner()->getPathName() : "");
     int selectedId = selectableItems->getSelectedId();
 
     sofa::type::vector<std::string> descriptiveItems;
@@ -483,7 +507,7 @@ void DataWidget<helper::BaseSelectableItem>::showWidget(
         charArray[i] = descriptiveItems[i].data();
     }
 
-    if (ImGui::Combo((label + "##" + id).c_str(), &selectedId, charArray.get(),
+    if (ImGui::Combo(("##" + id).c_str(), &selectedId, charArray.get(),
         static_cast<int>(selectableItems->getNumberOfItems())))
     {
         const_cast<helper::BaseSelectableItem*>(selectableItems)->setSelectedId(selectedId);
@@ -499,10 +523,10 @@ template<>
 void DataWidget<type::RGBAColor>::showWidget(MyData& data)
 {
     const auto& colorData = data.getValue();
-    const auto& label = data.getName();
-    const auto id = data.getName() + data.getOwner()->getPathName();
+    const auto id = data.getName() + (data.getOwner() ? data.getOwner()->getPathName() : "");
+
     ImVec4 color { colorData.r(), colorData.g(), colorData.b(), colorData.a()};
-    if (ImGui::ColorEdit4((label + "##" + id).c_str(), (float*)&color, ImGuiColorEditFlags_DisplayRGB))
+    if (ImGui::ColorEdit4(("##" + id).c_str(), (float*)&color, ImGuiColorEditFlags_DisplayRGB))
     {
         data.setValue(type::RGBAColor(color.x, color.y, color.z, color.w));
     }
@@ -682,15 +706,21 @@ const bool dw_vector_vec6f = DataWidgetFactory::Add<sofa::type::vector<sofa::typ
 const bool dw_vector_vec8d = DataWidgetFactory::Add<sofa::type::vector<sofa::type::Vec<8, double> > >();
 const bool dw_vector_vec8f = DataWidgetFactory::Add<sofa::type::vector<sofa::type::Vec<8, float> > >();
 
-const bool dw_vector_rigid2d = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidCoord<2, double> > >();
-const bool dw_vector_rigid2f = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidCoord<2, float> > >();
+const bool dw_vector_rigidcoord2d = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidCoord<2, double> > >();
+const bool dw_vector_rigidcoord2f = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidCoord<2, float> > >();
 
-const bool dw_vector_rigid3d = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidCoord<3, double> > >();
-const bool dw_vector_rigid3f = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidCoord<3, float> > >();
+const bool dw_vector_rigidcoord3d = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidCoord<3, double> > >();
+const bool dw_vector_rigidcoord3f = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidCoord<3, float> > >();
+
+const bool dw_vector_rigidderiv2d = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidDeriv<2, double> > >();
+const bool dw_vector_rigidderiv2f = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidDeriv<2, float> > >();
+
+const bool dw_vector_rigidderiv3d = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidDeriv<3, double> > >();
+const bool dw_vector_rigidderiv3f = DataWidgetFactory::Add<sofa::type::vector<sofa::defaulttype::RigidDeriv<3, float> > >();
 
 const bool dw_vector_edge = DataWidgetFactory::Add<sofa::type::vector<sofa::topology::Edge > >();
 const bool dw_vector_hexa = DataWidgetFactory::Add<sofa::type::vector<sofa::topology::Hexahedron > >();
-const bool dw_vector_penta = DataWidgetFactory::Add<sofa::type::vector<sofa::topology::Pentahedron > >();
+const bool dw_vector_penta = DataWidgetFactory::Add<sofa::type::vector<sofa::topology::Prism > >();
 const bool dw_vector_pyramid = DataWidgetFactory::Add<sofa::type::vector<sofa::topology::Pyramid > >();
 const bool dw_vector_quad = DataWidgetFactory::Add<sofa::type::vector<sofa::topology::Quad > >();
 const bool dw_vector_tetra = DataWidgetFactory::Add<sofa::type::vector<sofa::topology::Tetrahedron > >();

--- a/SofaImGui/src/SofaImGui/widgets/ImGuiDataWidget.h
+++ b/SofaImGui/src/SofaImGui/widgets/ImGuiDataWidget.h
@@ -134,7 +134,7 @@ inline void showWidget(sofa::core::objectmodel::BaseData& data)
     {
         BaseDataWidget::showWidgetAsText(data);
     }
-    ImGui::SetItemTooltip("type: %s", data.getData()->getValueTypeString().c_str());
+    ImGui::SetItemTooltip("data type: %s", data.getData()->getValueTypeString().c_str());
     ImGui::PopStyleVar();
     ImGui::PopItemWidth();
 }

--- a/SofaImGui/src/SofaImGui/widgets/ImGuiDataWidget.h
+++ b/SofaImGui/src/SofaImGui/widgets/ImGuiDataWidget.h
@@ -123,6 +123,9 @@ private:
 inline void showWidget(sofa::core::objectmodel::BaseData& data)
 {
     auto* widget = DataWidgetFactory::GetWidget(data);
+
+    ImGui::PushItemWidth(-1); // Fit container width
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
     if (widget)
     {
         widget->showWidget(data);
@@ -131,6 +134,9 @@ inline void showWidget(sofa::core::objectmodel::BaseData& data)
     {
         BaseDataWidget::showWidgetAsText(data);
     }
+    ImGui::SetItemTooltip("type: %s", data.getData()->getValueTypeString().c_str());
+    ImGui::PopStyleVar();
+    ImGui::PopItemWidth();
 }
 
 }

--- a/SofaImGui/src/SofaImGui/widgets/IntWidget.h
+++ b/SofaImGui/src/SofaImGui/widgets/IntWidget.h
@@ -26,15 +26,15 @@
 namespace sofaimgui
 {
 
-inline bool showIntWidget(const std::string& label, const std::string& id, int& value)
+inline bool showIntWidget(const std::string& id, int& value)
 {
-    return ImGui::InputInt((label + "##" + id).c_str(), &value, 0, 0, ImGuiInputTextFlags_None);
+    return ImGui::InputInt(("##" + id).c_str(), &value, 0, 0, ImGuiInputTextFlags_None);
 }
 
-inline bool showIntWidget(const std::string& label, const std::string& id, unsigned int& value)
+inline bool showIntWidget(const std::string& id, unsigned int& value)
 {
     int vui = value;
-    bool result = ImGui::InputInt((label + "##" + id).c_str(), &vui, 0, 0, ImGuiInputTextFlags_None);
+    bool result = ImGui::InputInt(("##" + id).c_str(), &vui, 0, 0, ImGuiInputTextFlags_None);
     value = abs(vui);
     return result;
 }
@@ -43,16 +43,11 @@ template<typename Int>
 void showIntWidget(sofa::Data<Int>& data)
 {
     Int initialValue = data.getValue();
-    const auto& label = data.getName();
-    const auto id = data.getName() + data.getOwner()->getPathName();
-    ImGui::PushItemWidth(-1); // Fit container width
-    ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1);
-    if (showIntWidget(label, id, initialValue))
+    const auto id = data.getName() + (data.getOwner() ? data.getOwner()->getPathName() : "");
+    if (showIntWidget(id, initialValue))
     {
         data.setValue(initialValue);
     }
-    ImGui::PopStyleVar();
-    ImGui::PopItemWidth();
 }
 
 }

--- a/SofaImGui/src/SofaImGui/widgets/LinearSpringWidget.h
+++ b/SofaImGui/src/SofaImGui/widgets/LinearSpringWidget.h
@@ -45,9 +45,20 @@ void showLinearSpringWidget(sofa::Data<sofa::component::solidmechanics::spring::
         spring.m2 = m2;
     }
 
-    showScalarWidget("Stiffness", id, spring.ks);
-    showScalarWidget("Damping", id, spring.kd);
-    showScalarWidget("Rest length", id, spring.initpos);
+    ImGui::AlignTextToFramePadding();
+    ImGui::Text("Stiffness");
+    ImGui::SameLine();
+    showScalarWidget(id, spring.ks);
+
+    ImGui::AlignTextToFramePadding();
+    ImGui::Text("Damping");
+    ImGui::SameLine();
+    showScalarWidget(id, spring.kd);
+
+    ImGui::AlignTextToFramePadding();
+    ImGui::Text("Rest length");
+    ImGui::SameLine();
+    showScalarWidget(id, spring.initpos);
 }
 
 template<class Real>
@@ -94,14 +105,13 @@ void showLinearSpringWidget(sofa::Data<sofa::type::vector<sofa::component::solid
             }
             ImGui::TableNextColumn();
 
-            showScalarWidget("", "s" + id + std::to_string(counter), spring.ks);
+            showScalarWidget("s" + id + std::to_string(counter), spring.ks);
             ImGui::TableNextColumn();
 
-            showScalarWidget("", "d" + id + std::to_string(counter), spring.kd);
+            showScalarWidget("d" + id + std::to_string(counter), spring.kd);
             ImGui::TableNextColumn();
 
-            showScalarWidget("", "l" + id + std::to_string(counter), spring.initpos);
-
+            showScalarWidget("l" + id + std::to_string(counter), spring.initpos);
 
             ++counter;
         }

--- a/SofaImGui/src/SofaImGui/widgets/ScalarWidget.h
+++ b/SofaImGui/src/SofaImGui/widgets/ScalarWidget.h
@@ -27,25 +27,22 @@
 namespace sofaimgui
 {
 
-inline bool showScalarWidget(const std::string& label, const std::string& id, float& value)
+inline bool showScalarWidget(const std::string& id, float& value)
 {
-    bool result = ImGui::LocalInputFloat((label + "##" + id).c_str(), &value, 0.0f, 0.0f, "", ImGuiInputTextFlags_None);
-    return result;
+    return ImGui::InputFloat(("##" + id).c_str(), &value, 0.0f, 0.0f);
 }
 
-inline bool showScalarWidget(const std::string& label, const std::string& id, double& value)
+inline bool showScalarWidget(const std::string& id, double& value)
 {
-    bool result = ImGui::LocalInputDouble((label + "##" + id).c_str(), &value, 0.0f, 0.0f, "", ImGuiInputTextFlags_None);
-    return result;
+    return ImGui::InputDouble(("##" + id).c_str(), &value, 0.0f, 0.0f);
 }
 
 template<typename Scalar>
 void showScalarWidget(sofa::Data<Scalar>& data)
 {
     Scalar initialValue = data.getValue();
-    const auto& label = data.getName();
-    const auto id = data.getName() + data.getOwner()->getPathName();
-    if (showScalarWidget(label, id, initialValue))
+    const auto id = data.getName() + (data.getOwner() ? data.getOwner()->getPathName() : "");
+    if (showScalarWidget(id, initialValue))
     {
         data.setValue(initialValue);
     }

--- a/SofaImGui/src/SofaImGui/widgets/VecVectorWidget.h
+++ b/SofaImGui/src/SofaImGui/widgets/VecVectorWidget.h
@@ -79,7 +79,9 @@ bool showLine(unsigned int lineNumber, const std::string& tableLabel, type::Vec<
     for (auto& v : vec)
     {
         ImGui::TableNextColumn();
-        showScalarWidget("", tableLabel + ImGui::TableGetColumnName(i++) + std::to_string(v), v);
+        ImGui::PushItemWidth(-1); // Fit container width
+        showScalarWidget(tableLabel + ImGui::TableGetColumnName(i++) + std::to_string(v), v);
+        ImGui::PopItemWidth();
     }
     ImGui::PopID();
     return false;
@@ -89,7 +91,10 @@ template<typename ValueType>
 bool showLine(unsigned int lineNumber, const std::string& tableLabel, ValueType& value)
 {
     ImGui::TableNextColumn();
-    return showScalarWidget("", tableLabel + std::to_string(lineNumber), value);
+    ImGui::PushItemWidth(-1); // Fit container width
+    bool result = showScalarWidget(tableLabel + std::to_string(lineNumber), value);
+    ImGui::PopItemWidth();
+    return result;
 }
 
 template<class T>
@@ -167,13 +172,114 @@ void showVecTableHeader(Data<sofa::type::vector<sofa::defaulttype::RigidCoord<2,
 }
 
 template< sofa::Size N, typename ValueType>
-void showWidgetT(Data<sofa::type::vector<sofa::defaulttype::RigidCoord<N, ValueType> > >& data)
+void showVecTableHeader(Data<sofa::type::vector<sofa::defaulttype::RigidDeriv<N, ValueType> > >&)
+{
+    ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+    for (unsigned int i = 0; i < sofa::defaulttype::RigidDeriv<N, ValueType>::total_size; ++i)
+    {
+        ImGui::TableSetupColumn(std::to_string(i).c_str());
+    }
+}
+
+template<typename ValueType>
+void showVecTableHeader(Data<sofa::type::vector<sofa::defaulttype::RigidDeriv<3, ValueType> > >&)
+{
+    ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableSetupColumn("X");
+    ImGui::TableSetupColumn("Y");
+    ImGui::TableSetupColumn("Z");
+
+    ImGui::TableSetupColumn("rX");
+    ImGui::TableSetupColumn("rY");
+    ImGui::TableSetupColumn("rZ");
+}
+
+template<typename ValueType>
+void showVecTableHeader(Data<sofa::type::vector<sofa::defaulttype::RigidDeriv<2, ValueType> > >&)
+{
+    ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableSetupColumn("X");
+    ImGui::TableSetupColumn("Y");
+
+    ImGui::TableSetupColumn("w");
+}
+
+template< sofa::Size N, typename ValueType>
+void showRigidLine(sofa::defaulttype::RigidCoord<N, ValueType>& vec, const unsigned int& counter)
+{
+    int j=0;
+    for (auto& v : vec.getCenter())
+    {
+        ImGui::TableNextColumn();
+        ImGui::PushID(j++);
+        ImGui::PushItemWidth(-1); // Fit container width
+        showScalarWidget("pos" + std::to_string(counter), v);
+        ImGui::PopItemWidth();
+        ImGui::PopID();
+    }
+    if constexpr (std::is_scalar_v<std::decay_t<decltype(vec.getOrientation())> >)
+    {
+        ImGui::TableNextColumn();
+        ImGui::Text("%f", vec.getOrientation());
+    }
+    else
+    {
+        for (unsigned int i = 0 ; i < 4; ++i)
+        {
+            ImGui::TableNextColumn();
+            auto& v = vec.getOrientation()[i];
+            ImGui::PushID(i);
+            ImGui::PushItemWidth(-1); // Fit container width
+            showScalarWidget("orien" + std::to_string(counter), v);
+            ImGui::PopItemWidth();
+            ImGui::PopID();
+        }
+    }
+}
+
+
+template< sofa::Size N, typename ValueType>
+void showRigidLine(sofa::defaulttype::RigidDeriv<N, ValueType>& vec, const unsigned int& counter)
+{
+    int j=0;
+    for (auto& v : vec.getVCenter())
+    {
+        ImGui::TableNextColumn();
+        ImGui::PushID(j++);
+        ImGui::PushItemWidth(-1); // Fit container width
+        showScalarWidget("pos" + std::to_string(counter), v);
+        ImGui::PopItemWidth();
+        ImGui::PopID();
+    }
+    if constexpr (std::is_scalar_v<std::decay_t<decltype(vec.getVOrientation())> >)
+    {
+        ImGui::TableNextColumn();
+        ImGui::Text("%f", vec.getVOrientation());
+    }
+    else
+    {
+        for (unsigned int i = 0 ; i < 3; ++i)
+        {
+            ImGui::TableNextColumn();
+            auto& v = vec.getVOrientation()[i];
+            ImGui::PushID(i);
+            ImGui::PushItemWidth(-1); // Fit container width
+            showScalarWidget("orien" + std::to_string(counter), v);
+            ImGui::PopItemWidth();
+            ImGui::PopID();
+        }
+    }
+}
+
+template<typename ValueType>
+void showWidgetT(Data<sofa::type::vector<ValueType> >& data)
 {
     static ImGuiTableFlags flags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchSame | ImGuiTableFlags_Resizable | ImGuiTableFlags_ContextMenuInBody | ImGuiTableFlags_RowBg;
     auto accessor = helper::getWriteAccessor(data);
     int dataSize = accessor->size();
     ImVec2 innerWidth = ImVec2(0.0f, ImGui::GetFrameHeightWithSpacing() * std::min(dataSize + 1, 11));
-    if (ImGui::BeginTable((data.getName() + data.getOwner()->getPathName()).c_str(), sofa::defaulttype::RigidCoord<N, ValueType>::total_size + 1, flags, innerWidth))
+
+    if (ImGui::BeginTable((data.getName() + data.getOwner()->getPathName()).c_str(), ValueType::total_size + 1, flags, innerWidth))
     {
         showVecTableHeader(data);
 
@@ -186,31 +292,7 @@ void showWidgetT(Data<sofa::type::vector<sofa::defaulttype::RigidCoord<N, ValueT
             ImGui::TableNextColumn();
             ImGui::AlignTextToFramePadding();
             ImGui::Text("%d", counter++);
-            int i=0;
-            for (auto& v : vec.getCenter())
-            {
-                ImGui::TableNextColumn();
-                ImGui::PushID(i++);
-                showScalarWidget("", "pos" + std::to_string(counter), v);
-                ImGui::PopID();
-
-            }
-            if constexpr (std::is_scalar_v<std::decay_t<decltype(vec.getOrientation())> >)
-            {
-                ImGui::TableNextColumn();
-                ImGui::Text("%f", vec.getOrientation());
-            }
-            else
-            {
-                for (unsigned int i = 0 ; i < 4; ++i)
-                {
-                    ImGui::TableNextColumn();
-                    auto& v = vec.getOrientation()[i];
-                    ImGui::PushID(i);
-                    showScalarWidget("", "orien" + std::to_string(counter), v);
-                    ImGui::PopID();
-                }
-            }
+            showRigidLine(vec, counter);
         }
 
         ImGui::EndTable();

--- a/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
+++ b/SofaImGui/src/SofaImGui/widgets/Widgets.cpp
@@ -167,8 +167,7 @@ bool LocalCheckBoxEx(const char* label, bool* v)
 
     const float square_sz = GetFrameHeight();
     const ImVec2 pos = window->DC.CursorPos;
-    ImVec2 pos2 = ImVec2(square_sz + (label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f),
-                               label_size.y + style.FramePadding.y * 2.0f);
+    ImVec2 pos2 = ImVec2(square_sz + (label_size.x > 0.0f ? style.ItemInnerSpacing.x + label_size.x : 0.0f), label_size.y + style.FramePadding.y * 2.0f);
     const ImRect total_bb(pos, ImVec2(pos.x + pos2.x, pos.y + pos2.y));
     ItemSize(total_bb, style.FramePadding.y);
     if (!ItemAdd(total_bb, id))


### PR DESCRIPTION
**In this PR:**
- remove the label of all widgets as it is redundant with the header (and it is needed for #94)
- add RigidDeriv widget
- show the type of the data in the tooltip (useful for python bindings, when you have to specify the type)
- each widget fits its container width
- also use the default widget for scalar, which fixes #112 

**Screenshot**

<img width="2884" height="1671" alt="Screenshot from 2026-04-28 13-55-42" src="https://github.com/user-attachments/assets/304161ca-7d5a-4dd9-84ff-7177be3df0e6" />
