### PR TITLE
[SceneGraphWindow] highlight ogl in nodes without using tags

### DIFF
--- a/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
@@ -450,14 +450,18 @@ void SceneGraphWindow::showNode(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::simula
         }
     }
 
-    if (isNodeSelected && !node->hasTag(selectedTag))
+    if (isNodeSelected && node!=m_currentHighlightedNode)
     {
-        node->addTag(selectedTag);
+        m_currentHighlightedNode = node;
+        if (!m_previousHighlightedNode)
+            m_previousHighlightedNode = m_currentHighlightedNode;
         highlightOglModels(node);
     }
-    else if (!isNodeSelected && node->hasTag(selectedTag))
+    else if (!isNodeSelected && node==m_previousHighlightedNode)
     {
-        node->removeTag(selectedTag);
+        m_previousHighlightedNode = nullptr;
+        if (node==m_currentHighlightedNode)
+            m_currentHighlightedNode = nullptr;
         resetOglModels(node);
     }
 
@@ -1093,7 +1097,7 @@ void SceneGraphWindow::resetOglModels(sofa::simulation::Node *node)
 
         for (const auto child : node->getChildren())
         {
-            if (m_selection.empty() || !child->hasTag(selectedTag))
+            if (m_selection.empty() || !m_selection.contains(child))
                 resetOglModels(dynamic_cast<sofa::simulation::Node*>(child));
         }
     }

--- a/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.h
@@ -53,6 +53,8 @@ protected:
     std::set<sofa::core::objectmodel::Base::SPtr> m_selection;
 
     sofa::type::Material m_highlightMaterial;
+    sofa::simulation::Node* m_currentHighlightedNode{nullptr};
+    sofa::simulation::Node* m_previousHighlightedNode{nullptr};
 
     int m_modifyingRow{-1};
 
@@ -68,8 +70,6 @@ protected:
     bool m_showFilteredWarning = false;
     bool m_showFilteredError = false;
     bool m_showFilteredInfo = false;
-
-    inline static const sofa::core::objectmodel::Tag selectedTag = sofa::core::objectmodel::Tag("GUISelected");
 
     void showGraph(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWindowFlags &windowFlags);
     void showNode(sofaglfw::SofaGLFWBaseGUI *baseGUI, sofa::simulation::Node* parent, sofa::simulation::Node* node, const ImGuiTextFilter& filter);


### PR DESCRIPTION
Highlight node without using `Tag` as it is not meant for that.
The current implementation is breaking.  