### PR TITLE
[RecordVideoWindow] generate filename option

### DIFF
--- a/SofaImGui/src/SofaImGui/windows/RecordVideoWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/RecordVideoWindow.cpp
@@ -54,11 +54,9 @@ void RecordVideoWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImG
 
     if (isOpen())
     {
-        ImGui::SetNextWindowSize(ImVec2(0., 0.), ImGuiCond_Once);
+        ImGui::SetNextWindowSize(ImVec2(0., 0.));
         if (ImGui::Begin(getName().c_str(), &m_isOpen, windowFlags))
         {
-            // float rightPosition = ImGui::GetCursorPosX() + ImGui::GetWindowSize().x - ImGui::GetFrameHeightWithSpacing()*2.;
-
             static bool record = false;
             ImVec2 buttonSize(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
 
@@ -70,11 +68,24 @@ void RecordVideoWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImG
             ImGui::Text("Output file");
             ImGui::SameLine();
             static std::string filename = baseGUI->generateFilename("video", "");
-            ImGui::InputText("##OutputFile", &filename);
+            static bool generatedFilename = true;
+            if (ImGui::InputText("##OutputFile", &filename))
+                generatedFilename = false;
             if (filename.empty())
                 filename = baseGUI->generateFilename("video", "");
             ImGui::SameLine();
             ImGui::TextDisabled(".mp4");
+            ImGui::SameLine();
+            if (generatedFilename)
+                ImGui::BeginDisabled();
+            if(ImGui::LocalButton(ICON_FA_ROTATE))
+            {
+                generatedFilename = true;
+                filename = baseGUI->generateFilename("video", "");
+            }
+            if (generatedFilename)
+                ImGui::EndDisabled();
+            ImGui::SetItemTooltip("Generate filename");
 
             // Interval time
             ImGui::AlignTextToFramePadding();
@@ -101,12 +112,14 @@ void RecordVideoWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImG
             ImGui::PushStyleColor(ImGuiCol_ButtonHovered, sofaimgui::blendColors(ImColor(COLOR_RED), ImVec4(0.5,0.,0.,1.), 0.1));
             ImGui::PushStyleColor(ImGuiCol_ButtonActive, sofaimgui::blendColors(ImColor(COLOR_RED), ImVec4(0.5,0.,0.,1.), 0.3));
 
-            // ImGui::SetCursorPosX(rightPosition); // Set the position to the right of the area
             static bool clicked = false;
             if (ImGui::Button(record? ICON_FA_STOP " Stop": ICON_DVS_CIRCLE_FULL" Record"))
             {
                 clicked = true;
                 record = !record;
+
+                if (generatedFilename)
+                    filename = baseGUI->generateFilename("video", "");
             }
             ImGui::SetItemTooltip(record? "Stop recording": "Start recording");
 


### PR DESCRIPTION
**In this PR**:
- Continue to generate a new filename if the user did not change it
- Add a button to generate a new filename if the user did change it (disabled on unchanged)
- Resize the window to auto fit the content (other conditions like `once` or `appearing` do not work as expected)

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/d1720ebd-26ac-4c19-804a-def895c7d661" />
