### PR TITLE
[SofaImGui] Save workbenches state

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -140,9 +140,15 @@ void ImGuiGUIEngine::saveProject(const bool& saveAs)
     // Save windows settings in project file
     for (const auto& window : m_windows)
     {
-        const auto& windowName = window.get().getName();
-        windowSettings.setSetting(windowName.c_str(), "open", window.get().isOpen());
-        auto imguiWindow = ImGui::FindWindowByName(window.get().getLabel().c_str());
+        auto& w = window.get();
+        const auto& windowName = w.getName();
+
+        std::string settingName = (getWorkbenchName(workbench));
+        settingName += ".";
+        settingName += windowName;
+
+        windowSettings.setSetting(settingName.c_str(), "open", w.isOpen());
+        auto imguiWindow = ImGui::FindWindowByName(w.getLabel().c_str());
         if (imguiWindow)
             windowSettings.setSetting(windowName.c_str(), "dockId", std::to_string(imguiWindow->DockId));
     }
@@ -156,8 +162,9 @@ void ImGuiGUIEngine::saveProject(const bool& saveAs)
             auto dock = ImGui::DockContextFindNodeByID(g, dockID);
             if (dock)
             {
-                windowSettings.setSetting(std::to_string(dockID).c_str(), "width", double(dock->Size[0]));
-                windowSettings.setSetting(std::to_string(dockID).c_str(), "height", double(dock->Size[1]));
+                std::string settingName = std::to_string(dockID) + getWorkbenchName(workbench);
+                windowSettings.setSetting(settingName.c_str(), "width", double(dock->Size[0]));
+                windowSettings.setSetting(settingName.c_str(), "height", double(dock->Size[1]));
             }
         }
     }
@@ -199,10 +206,10 @@ void ImGuiGUIEngine::setDockSizeFromFile(const ImGuiID& id)
 {
     if (ImGui::DockBuilderGetNode(id))
     {
-        const auto dockLabel = std::to_string(id);
         auto& windowsSettings = windows::WindowsSettings::getInstance();
-        auto size = ImVec2(windowsSettings.getSetting(dockLabel.c_str(), "width", 0.),
-                           windowsSettings.getSetting(dockLabel.c_str(), "height", 0.));
+        std::string settingName = std::to_string(id) + getWorkbenchName(workbench);
+        auto size = ImVec2(windowsSettings.getSetting(settingName.c_str(), "width", 0.),
+                           windowsSettings.getSetting(settingName.c_str(), "height", 0.));
 
         if (size.x > 0 && size.y > 0)
             ImGui::DockBuilderSetNodeSize(id, size);
@@ -546,6 +553,7 @@ void ImGuiGUIEngine::changeWorkbench(Workbench wb)
 {
     workbench = wb;
     m_baseGUI->setMouseInteractionEnabled(workbench==Workbench::SIMULATION_MODE);
+    enableWindows();
 }
 
 void ImGuiGUIEngine::showViewportWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI)
@@ -1052,7 +1060,14 @@ void ImGuiGUIEngine::enableWindows()
     // Enable the windows based on file
     for (const auto& window : m_windows)
     {
-        window.get().setOpen(windowsSettings.getSetting(window.get().getName().c_str(), "open", window.get().getDefaultIsOpen()));
+        auto& w = window.get();
+        std::string settingName = (getWorkbenchName(workbench));
+        settingName += ".";
+        settingName += w.getName();
+
+        w.setOpen(windowsSettings.getSetting(settingName.c_str(),
+                                             "open",
+                                             w.getDefaultIsOpen() && w.isEnabledInWorkbench() && w.isEnabled()));
     }
     initDockSpace(true);
 }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -1067,7 +1067,7 @@ void ImGuiGUIEngine::enableWindows()
 
         w.setOpen(windowsSettings.getSetting(settingName.c_str(),
                                              "open",
-                                             w.getDefaultIsOpen() && w.isEnabledInWorkbench() && w.isEnabled()));
+                                             w.getDefaultIsOpen() && w.isEnabledInWorkbench() && w.isEnabledByState()));
     }
     initDockSpace(true);
 }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -98,9 +98,9 @@ public:
     std::shared_ptr<windows::StateWindow> m_stateWindow = std::make_shared<windows::StateWindow>("State", false);
 
     windows::ViewportWindow     m_viewportWindow     = windows::ViewportWindow("Viewport", true, m_stateWindow);
-    windows::SceneGraphWindow   m_sceneGraphWindow   = windows::SceneGraphWindow("Scene Graph", false);
-    windows::ComponentsWindow   m_componentsWindow   = windows::ComponentsWindow("Components", false);
-    windows::LogWindow          m_logWindow          = windows::LogWindow("Log", false);
+    windows::SceneGraphWindow   m_sceneGraphWindow   = windows::SceneGraphWindow("Scene Graph", true);
+    windows::ComponentsWindow   m_componentsWindow   = windows::ComponentsWindow("Components", true);
+    windows::LogWindow          m_logWindow          = windows::LogWindow("Log", true);
     windows::IOWindow           m_IOWindow           = windows::IOWindow("Input/Output", false);
     windows::ProgramWindow      m_programWindow      = windows::ProgramWindow("Program", true);
     windows::PlottingWindow     m_plottingWindow     = windows::PlottingWindow("Plotting", true);

--- a/SofaImGui/src/SofaImGui/windows/BaseWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/BaseWindow.cpp
@@ -35,6 +35,13 @@ BaseWindow::BaseWindow()
     m_workbenches = Workbench::LIVE_CONTROL | Workbench::SCENE_EDITOR | Workbench::SIMULATION_MODE;
 }
 
+BaseWindow::BaseWindow(std::string name, bool defaultIsOpen)
+    : BaseWindow()
+{
+    m_name = name;
+    m_defaultIsOpen = defaultIsOpen;
+}
+
 void BaseWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI, const ImGuiWindowFlags &windowFlags)
 {
     SOFA_UNUSED(baseGUI);

--- a/SofaImGui/src/SofaImGui/windows/BaseWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/BaseWindow.h
@@ -112,7 +112,7 @@ class SOFAIMGUI_API BaseWindow
 
     /// The window may have nothing to display. It should override this method with the corresponding checks.
     /// For example: the PlottingWindow needs data to plot, if none are given, the window is disabled.
-    virtual bool isEnabled() {return true;}
+    virtual bool isEnabledByState() {return true;}
 
    protected:
 

--- a/SofaImGui/src/SofaImGui/windows/BaseWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/BaseWindow.h
@@ -79,6 +79,7 @@ class SOFAIMGUI_API BaseWindow
 {
    public:
     BaseWindow();
+    BaseWindow(std::string name, bool defaultIsOpen);
     ~BaseWindow() = default;
 
     /// Implements the drawing of the window
@@ -109,19 +110,19 @@ class SOFAIMGUI_API BaseWindow
     /// Returns true if the window is enabled in the current workbench
     bool isEnabledInWorkbench();
 
-   protected:
-
     /// The window may have nothing to display. It should override this method with the corresponding checks.
     /// For example: the PlottingWindow needs data to plot, if none are given, the window is disabled.
-    virtual bool enabled() {return true;}
+    virtual bool isEnabled() {return true;}
+
+   protected:
 
     /// Structured message display (info icon + message)
     void showInfoMessage(const char* message);
 
     bool m_isOpen{false}; /// The user choice to open the window or not
+    bool m_defaultIsOpen{false}; /// The default open state when there is no project file
     std::string m_name = "Window"; /// The name of the window
     std::string m_labelname; /// The label of the window
-    bool m_defaultIsOpen{false}; /// The default open state when there is no project file
     int m_workbenches;
 
 };

--- a/SofaImGui/src/SofaImGui/windows/ComponentsWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ComponentsWindow.cpp
@@ -51,10 +51,6 @@ void ComponentsWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGu
 
     if (isOpen())
     {
-        // Note for later
-        // if not isEnabledInWorkbench()
-        // Disable drag and drop
-
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen, windowFlags))
         {
             if (workbench == Workbench::SCENE_EDITOR)
@@ -105,9 +101,6 @@ void ComponentsWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGu
                 ImGui::PopStyleColor();
             }
             ImGui::EndChild();
-
-            // if (ImGui::Button(ICON_FA_SAVE" "))
-                // saveFile();
         }
         ImGui::End();
     }

--- a/SofaImGui/src/SofaImGui/windows/ComponentsWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ComponentsWindow.cpp
@@ -35,11 +35,9 @@ namespace sofaimgui::windows
 {
 
 ComponentsWindow::ComponentsWindow(const std::string& name, const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
     m_workbenches = Workbench::SCENE_EDITOR;
-
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string ComponentsWindow::getDescription()

--- a/SofaImGui/src/SofaImGui/windows/IOWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/IOWindow.cpp
@@ -40,12 +40,9 @@
 namespace sofaimgui::windows {
 
 IOWindow::IOWindow(const std::string& name, const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
     m_workbenches = Workbench::LIVE_CONTROL | Workbench::SIMULATION_MODE;
-
-    m_defaultIsOpen = false;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 
 #if SOFAIMGUI_WITH_ROS
     rclcpp::init(0, nullptr);

--- a/SofaImGui/src/SofaImGui/windows/LogWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/LogWindow.cpp
@@ -44,10 +44,8 @@
 namespace sofaimgui::windows {
 
 LogWindow::LogWindow(const std::string& name, const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
-    m_defaultIsOpen = false;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string LogWindow::getDescription()

--- a/SofaImGui/src/SofaImGui/windows/MouseManagerWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MouseManagerWindow.cpp
@@ -31,10 +31,8 @@ namespace sofaimgui::windows {
 
 MouseManagerWindow::MouseManagerWindow(const std::string& name,
                                        const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
-    m_defaultIsOpen = false;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string MouseManagerWindow::getDescription()

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
@@ -114,7 +114,7 @@ void MoveWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI, const ImGuiWindo
     {
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen, windowFlags))
         {
-            if (isEnabled())
+            if (isEnabledByState())
             {
                 if (m_IPController != nullptr)
                 {

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.cpp
@@ -35,12 +35,10 @@ namespace sofaimgui::windows {
 
 MoveWindow::MoveWindow(const std::string& name,
                          const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
     m_workbenches = Workbench::LIVE_CONTROL | Workbench::SIMULATION_MODE;
 
-    m_defaultIsOpen = true;
-    m_name = name;
-    m_isOpen = isWindowOpen;
     m_moveType = MoveType::SLIDERS;
 
     m_movePad = ImGui::MovePad("##MovePad", "X", "Z", "Y",
@@ -116,7 +114,7 @@ void MoveWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI, const ImGuiWindo
     {
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen, windowFlags))
         {
-            if (enabled())
+            if (isEnabled())
             {
                 if (m_IPController != nullptr)
                 {

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.h
@@ -94,7 +94,7 @@ class SOFAIMGUI_API MoveWindow : public BaseWindow
 
     ImGui::MovePad m_movePad;
 
-    bool isEnabled() override {return (m_IPController!=nullptr || !m_actuators.empty());}
+    bool isEnabledByState() override {return (m_IPController!=nullptr || !m_actuators.empty());}
 
     bool showSliderDouble(const char *name, const char* label1, const char *label2, double* v, const double& min, const double& max, const ImVec4 &color);
     bool showSliderDouble(const char *name, const char* label1, const char *label2, double* v, const double& min, const double& max);

--- a/SofaImGui/src/SofaImGui/windows/MoveWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/MoveWindow.h
@@ -94,7 +94,7 @@ class SOFAIMGUI_API MoveWindow : public BaseWindow
 
     ImGui::MovePad m_movePad;
 
-    bool enabled() override {return (m_IPController!=nullptr || !m_actuators.empty());}
+    bool isEnabled() override {return (m_IPController!=nullptr || !m_actuators.empty());}
 
     bool showSliderDouble(const char *name, const char* label1, const char *label2, double* v, const double& min, const double& max, const ImVec4 &color);
     bool showSliderDouble(const char *name, const char* label1, const char *label2, double* v, const double& min, const double& max);

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
@@ -137,7 +137,7 @@ void MyRobotWindow::addSetting(const Setting &setting, const std::string &group)
     }
 }
 
-bool MyRobotWindow::isEnabled()
+bool MyRobotWindow::isEnabledByState()
 {
     return (m_connection.listAvailablePortsCallback || !m_informationGroups.empty() || !m_settingGroups.empty());
 }
@@ -150,7 +150,7 @@ void MyRobotWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWi
     {
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen, windowFlags))
         {
-            if (isEnabled())
+            if (isEnabledByState())
             {
                 ImGui::Spacing();
 

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.cpp
@@ -38,13 +38,10 @@ namespace sofaimgui::windows {
 std::string MyRobotWindow::DEFAULTGROUP = "empty";
 
 MyRobotWindow::MyRobotWindow(const std::string& name,
-                         const bool& isWindowOpen)
+                             const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
     m_workbenches = Workbench::LIVE_CONTROL;
-
-    m_defaultIsOpen = true;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string MyRobotWindow::getDescription()
@@ -140,7 +137,7 @@ void MyRobotWindow::addSetting(const Setting &setting, const std::string &group)
     }
 }
 
-bool MyRobotWindow::enabled()
+bool MyRobotWindow::isEnabled()
 {
     return (m_connection.listAvailablePortsCallback || !m_informationGroups.empty() || !m_settingGroups.empty());
 }
@@ -153,7 +150,7 @@ void MyRobotWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWi
     {
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen, windowFlags))
         {
-            if (enabled())
+            if (isEnabled())
             {
                 ImGui::Spacing();
 

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.h
@@ -79,7 +79,7 @@ class SOFAIMGUI_API MyRobotWindow : public BaseWindow
     std::vector<InformationGroup> m_informationGroups;
     std::vector<SettingGroup> m_settingGroups;
 
-    bool enabled() override;
+    bool isEnabled() override;
 
     bool isInEmptyGroup(const std::string &group);
     bool showSliderDouble(const std::string &name, double* v, const double& min, const double& max);

--- a/SofaImGui/src/SofaImGui/windows/MyRobotWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/MyRobotWindow.h
@@ -79,7 +79,7 @@ class SOFAIMGUI_API MyRobotWindow : public BaseWindow
     std::vector<InformationGroup> m_informationGroups;
     std::vector<SettingGroup> m_settingGroups;
 
-    bool isEnabled() override;
+    bool isEnabledByState() override;
 
     bool isInEmptyGroup(const std::string &group);
     bool showSliderDouble(const std::string &name, double* v, const double& min, const double& max);

--- a/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
@@ -113,7 +113,7 @@ void PlottingWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiW
     {
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen, ImGuiWindowFlags_NoScrollbar))
         {
-            if (!isEnabledInWorkbench() || !isEnabled())
+            if (!isEnabledInWorkbench() || !isEnabledByState())
                 showInfoMessage("This window is used to plot data over time. It currently has no data registered or is disabled in the active workbench.");
 
             if (!isEnabledInWorkbench())
@@ -144,7 +144,7 @@ void PlottingWindow::showButtons()
     ImGui::SameLine();
 
     // Export csv button
-    if (!isEnabled())
+    if (!isEnabledByState())
         ImGui::BeginDisabled();
 
     if (ImGui::LocalButton(ICON_FA_FILE_EXPORT))
@@ -152,7 +152,7 @@ void PlottingWindow::showButtons()
         exportData();
     }
 
-    if (!isEnabled())
+    if (!isEnabledByState())
     {
         ImGui::SetItemTooltip("No values to export");
         ImGui::EndDisabled();

--- a/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/PlottingWindow.cpp
@@ -37,12 +37,9 @@ namespace sofaimgui::windows {
 
 PlottingWindow::PlottingWindow(const std::string& name,
                                const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
     m_workbenches = Workbench::LIVE_CONTROL | Workbench::SIMULATION_MODE;
-
-    m_defaultIsOpen = true;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string PlottingWindow::getDescription()
@@ -116,7 +113,7 @@ void PlottingWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiW
     {
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen, ImGuiWindowFlags_NoScrollbar))
         {
-            if (!isEnabledInWorkbench() || !enabled())
+            if (!isEnabledInWorkbench() || !isEnabled())
                 showInfoMessage("This window is used to plot data over time. It currently has no data registered or is disabled in the active workbench.");
 
             if (!isEnabledInWorkbench())
@@ -147,7 +144,7 @@ void PlottingWindow::showButtons()
     ImGui::SameLine();
 
     // Export csv button
-    if (!enabled())
+    if (!isEnabled())
         ImGui::BeginDisabled();
 
     if (ImGui::LocalButton(ICON_FA_FILE_EXPORT))
@@ -155,7 +152,7 @@ void PlottingWindow::showButtons()
         exportData();
     }
 
-    if (!enabled())
+    if (!isEnabled())
     {
         ImGui::SetItemTooltip("No values to export");
         ImGui::EndDisabled();

--- a/SofaImGui/src/SofaImGui/windows/PlottingWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/PlottingWindow.h
@@ -89,7 +89,7 @@ class SOFAIMGUI_API PlottingWindow : public BaseWindow
     size_t m_nbRows{1};
     size_t m_nbCols{1};
 
-    bool enabled() override {return !m_data.empty();}
+    bool isEnabled() override {return !m_data.empty();}
 
     void exportData();
     void showButtons();

--- a/SofaImGui/src/SofaImGui/windows/PlottingWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/PlottingWindow.h
@@ -89,7 +89,7 @@ class SOFAIMGUI_API PlottingWindow : public BaseWindow
     size_t m_nbRows{1};
     size_t m_nbCols{1};
 
-    bool isEnabled() override {return !m_data.empty();}
+    bool isEnabledByState() override {return !m_data.empty();}
 
     void exportData();
     void showButtons();

--- a/SofaImGui/src/SofaImGui/windows/PluginsWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/PluginsWindow.cpp
@@ -34,10 +34,8 @@ namespace sofaimgui::windows {
 
 PluginsWindow::PluginsWindow(const std::string& name,
                              const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
-    m_defaultIsOpen = false;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string PluginsWindow::getDescription()

--- a/SofaImGui/src/SofaImGui/windows/ProfilerWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProfilerWindow.cpp
@@ -33,11 +33,9 @@
 namespace sofaimgui::windows {
 
 ProfilerWindow::ProfilerWindow(const std::string& name, const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
     m_workbenches = Workbench::LIVE_CONTROL | Workbench::SIMULATION_MODE;
-
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string ProfilerWindow::getDescription()

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
@@ -98,7 +98,7 @@ void ProgramWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWi
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen,
                         windowFlags | ImGuiWindowFlags_AlwaysAutoResize))
         {
-            if (isEnabled())
+            if (isEnabledByState())
             {
                 if (!isEnabledInWorkbench())
                 {

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
@@ -53,12 +53,9 @@ using sofa::type::Quat;
 
 ProgramWindow::ProgramWindow(const std::string& name,
                              const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
     m_workbenches = Workbench::LIVE_CONTROL | Workbench::SIMULATION_MODE;
-
-    m_defaultIsOpen = true;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string ProgramWindow::getDescription()
@@ -101,7 +98,7 @@ void ProgramWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWi
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen,
                         windowFlags | ImGuiWindowFlags_AlwaysAutoResize))
         {
-            if (enabled())
+            if (isEnabled())
             {
                 if (!isEnabledInWorkbench())
                 {

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.h
@@ -83,7 +83,7 @@ class SOFAIMGUI_API ProgramWindow : public BaseWindow
     std::string m_info;
     bool m_refreshInfo = false;
 
-    bool enabled() override {return m_IPController!=nullptr;}
+    bool isEnabled() override {return m_IPController!=nullptr;}
 
     void showProgramButtons(); /// The buttons of the program window (import, export, restart, repeat, etc.).
     void showCursorMarker(const int &nbCollaspedTracks); /// The red cursor marker.

--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.h
@@ -83,7 +83,7 @@ class SOFAIMGUI_API ProgramWindow : public BaseWindow
     std::string m_info;
     bool m_refreshInfo = false;
 
-    bool isEnabled() override {return m_IPController!=nullptr;}
+    bool isEnabledByState() override {return m_IPController!=nullptr;}
 
     void showProgramButtons(); /// The buttons of the program window (import, export, restart, repeat, etc.).
     void showCursorMarker(const int &nbCollaspedTracks); /// The red cursor marker.

--- a/SofaImGui/src/SofaImGui/windows/RecordVideoWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/RecordVideoWindow.cpp
@@ -37,10 +37,8 @@ namespace sofaimgui::windows {
 
 RecordVideoWindow::RecordVideoWindow(const std::string& name,
                                      const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
-    m_defaultIsOpen = false;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string RecordVideoWindow::getDescription()

--- a/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/SceneGraphWindow.cpp
@@ -39,12 +39,9 @@
 namespace sofaimgui::windows {
 
 SceneGraphWindow::SceneGraphWindow(const std::string& name, const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
     m_workbenches = Workbench::SCENE_EDITOR | Workbench::SIMULATION_MODE;
-
-    m_defaultIsOpen = false;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string SceneGraphWindow::getDescription()

--- a/SofaImGui/src/SofaImGui/windows/StateWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/StateWindow.cpp
@@ -29,10 +29,8 @@ namespace sofaimgui::windows {
 
 StateWindow::StateWindow(const std::string& name,
                          const bool& isWindowOpen)
+    : BaseWindow(name, isWindowOpen)
 {
-    m_defaultIsOpen = false;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string StateWindow::getDescription()
@@ -50,7 +48,7 @@ void StateWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWind
     SOFA_UNUSED(baseGUI);
     SOFA_UNUSED(windowFlags);
 
-    if (enabled() && isOpen())
+    if (isEnabled() && isOpen())
     {
         static bool openstate = true;
         ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.10f, 0.20f, 0.34f, 0.05f));

--- a/SofaImGui/src/SofaImGui/windows/StateWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/StateWindow.cpp
@@ -48,7 +48,7 @@ void StateWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWind
     SOFA_UNUSED(baseGUI);
     SOFA_UNUSED(windowFlags);
 
-    if (isEnabled() && isOpen())
+    if (isEnabledByState() && isOpen())
     {
         static bool openstate = true;
         ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.10f, 0.20f, 0.34f, 0.05f));

--- a/SofaImGui/src/SofaImGui/windows/StateWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/StateWindow.h
@@ -38,7 +38,7 @@ class SOFAIMGUI_API StateWindow : public BaseWindow
     void setSimulationState(const models::SimulationState &simulationState);
 
   protected:
-    bool isEnabled() override {return !m_simulationStateData.empty();}
+    bool isEnabledByState() override {return !m_simulationStateData.empty();}
 
     std::vector<models::SimulationState::StateData> m_simulationStateData;
 };

--- a/SofaImGui/src/SofaImGui/windows/StateWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/StateWindow.h
@@ -38,7 +38,7 @@ class SOFAIMGUI_API StateWindow : public BaseWindow
     void setSimulationState(const models::SimulationState &simulationState);
 
   protected:
-    bool enabled() override {return !m_simulationStateData.empty();}
+    bool isEnabled() override {return !m_simulationStateData.empty();}
 
     std::vector<models::SimulationState::StateData> m_simulationStateData;
 };

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -39,11 +39,9 @@
 namespace sofaimgui::windows {
 
 ViewportWindow::ViewportWindow(const std::string& name, const bool& isWindowOpen, std::shared_ptr<StateWindow> stateWindow)
-    : m_stateWindow(stateWindow)
+    : BaseWindow(name, isWindowOpen)
+    , m_stateWindow(stateWindow)
 {
-    m_defaultIsOpen = true;
-    m_name = name;
-    m_isOpen = isWindowOpen;
 }
 
 std::string ViewportWindow::getDescription()


### PR DESCRIPTION
**In this PR:**
- cleaning `defaultIsOpen`: set from `ImGuiGuiEngine`, also if the user did not specify to open the window --> `check defautIsOpen && isEnabled && isEnabledInWorkbench`  --> won't display, when not specified, a window which has nothing to show
- refactoring `BaseWindow` constructor
- save workbenches state (open windows, docks size)

https://github.com/user-attachments/assets/51755587-15dc-495b-a45e-c23102b53581

