### PR TITLE
[Style] fixes input text cursor color

### DIFF
--- a/SofaImGui/resources/Style.cpp
+++ b/SofaImGui/resources/Style.cpp
@@ -71,6 +71,7 @@ void setDeepDarkStyle()
 {
     ImVec4* colors = ImGui::GetStyle().Colors;
     colors[ImGuiCol_Text]                   = ImColor(COLOR_WHITE);
+    colors[ImGuiCol_InputTextCursor]        = ImColor(COLOR_WHITE);
     colors[ImGuiCol_WarningText]            = ImVec4(0.92f, 0.95f, 0.83f, 1.00f);
     colors[ImGuiCol_ButtonText]             = ImColor(COLOR_WHITE);
     colors[ImGuiCol_TabText]                = ImColor(COLOR_WHITE);
@@ -134,6 +135,7 @@ void setLightStyle()
 {
     ImVec4* colors = ImGui::GetStyle().Colors;
     colors[ImGuiCol_Text]                   = ImColor(COLOR_BLACK);
+    colors[ImGuiCol_InputTextCursor]        = ImColor(COLOR_BLACK);
     colors[ImGuiCol_WarningText]            = ImVec4(0.52f, 0.55f, 0.43f, 1.00f);
     colors[ImGuiCol_ButtonText]             = ImColor(COLOR_WHITE);
     colors[ImGuiCol_TabText]                = ImColor(COLOR_BLACK);

--- a/SofaImGui/resources/Style.cpp
+++ b/SofaImGui/resources/Style.cpp
@@ -71,7 +71,7 @@ void setDeepDarkStyle()
 {
     ImVec4* colors = ImGui::GetStyle().Colors;
     colors[ImGuiCol_Text]                   = ImColor(COLOR_WHITE);
-    colors[ImGuiCol_InputTextCursor]        = ImColor(COLOR_WHITE);
+    colors[ImGuiCol_InputTextCursor]        = colors[ImGuiCol_Text];
     colors[ImGuiCol_WarningText]            = ImVec4(0.92f, 0.95f, 0.83f, 1.00f);
     colors[ImGuiCol_ButtonText]             = ImColor(COLOR_WHITE);
     colors[ImGuiCol_TabText]                = ImColor(COLOR_WHITE);
@@ -135,7 +135,7 @@ void setLightStyle()
 {
     ImVec4* colors = ImGui::GetStyle().Colors;
     colors[ImGuiCol_Text]                   = ImColor(COLOR_BLACK);
-    colors[ImGuiCol_InputTextCursor]        = ImColor(COLOR_BLACK);
+    colors[ImGuiCol_InputTextCursor]        = colors[ImGuiCol_Text];
     colors[ImGuiCol_WarningText]            = ImVec4(0.52f, 0.55f, 0.43f, 1.00f);
     colors[ImGuiCol_ButtonText]             = ImColor(COLOR_WHITE);
     colors[ImGuiCol_TabText]                = ImColor(COLOR_BLACK);


### PR DESCRIPTION
Was white by default, thus we could not see it on light mode