### PR TITLE
[ViewportWindow] Fixes camera transforms

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -780,6 +780,10 @@ void SofaGLFWBaseGUI::setMousePos(int xpos, int ypos) {
     }
 }
 
+void SofaGLFWBaseGUI::setDisabledMouse(bool disabled) {
+    glfwSetInputMode(m_firstWindow, GLFW_CURSOR, disabled? GLFW_CURSOR_DISABLED: GLFW_CURSOR_NORMAL);
+}
+
 void SofaGLFWBaseGUI::window_pos_callback(GLFWwindow* window, int xpos, int ypos)
 {
     SofaGLFWBaseGUI* gui = static_cast<SofaGLFWBaseGUI*>(glfwGetWindowUserPointer(window));

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -108,6 +108,7 @@ public:
 
     void moveRayPickInteractor(int eventX, int eventY) override ;
     void setMousePos(int xpos, int ypos);
+    void setDisabledMouse(bool constraint);
 
     bool initRecorder(int width, int height,
                       unsigned int framerate=60, unsigned int bitrate=2000000,

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -171,6 +171,8 @@ void SofaGLFWWindow::resetSimulationView(sofaglfw::SofaGLFWBaseGUI *baseGUI)
                     msg_error("GUI") << "Could not import camera parameters from " << viewFileName << ".";
                 }
             }
+            // TODO: lookAt should be correctly initialized in BaseCamera
+            camera->d_lookAt.setValue(camera->getLookAtFromOrientation(camera->getPosition(), camera->getDistance(), camera->getOrientation()));
         }
     }
 }

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -233,7 +233,6 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     dpos *= 1e-3;
 
     // Buttons
-    ImVec2 buttonSize = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
     bool translate = false;
     if (ImGui::Begin("ViewportChildLeftButtons", &m_isOpen, ImGuiWindowFlags_ChildWindow | ImGuiWindowFlags_AlwaysAutoResize |
                                                             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove))
@@ -246,7 +245,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         std::string title = (cameraButtonsCollapsed) ? ICON_FA_CHEVRON_DOWN : ICON_FA_CHEVRON_UP;
         title+="##viewoptions";
 
-        if(ImGui::Button(title.c_str(), ImVec2(buttonSize.x, buttonSize.y)))
+        if(ImGui::LocalButton(title.c_str()))
         {
             cameraButtonsCollapsed = !cameraButtonsCollapsed;
             windowsSettings.setSetting(m_name.c_str(), WS_VIEWPORT_CAMERABUTTONCOLLAPSE, cameraButtonsCollapsed);
@@ -380,11 +379,11 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         }
     }
 
-    const double &distance = camera->getDistance();
-    const sofa::type::Vec3 &lookAt = camera->getLookAtFromOrientation(camera->getPosition(), distance, camera->getOrientation()); // TODO: This should be initialize in BaseCamera
     bool rotate = false;
-
     { // Orientation gizmo clicked
+        const double &distance = camera->getDistance();
+        const sofa::type::Vec3 &lookAt = camera->getLookAtFromOrientation(camera->getPosition(), distance, camera->getOrientation()); // TODO: This should be initialize in BaseCamera
+
         auto getRotationCoef = [dpos, camera](sofa::type::Vec3 axis) -> float
         {
             auto cpos = camera->worldToScreenPoint(axis);

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -382,7 +382,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     bool rotate = false;
     { // Orientation gizmo clicked
         const double &distance = camera->getDistance();
-        const sofa::type::Vec3 &lookAt = camera->getLookAtFromOrientation(camera->getPosition(), distance, camera->getOrientation()); // TODO: This should be initialize in BaseCamera
+        const sofa::type::Vec3 &lookAt = camera->getLookAt();
 
         auto getRotationCoef = [dpos, camera](sofa::type::Vec3 axis) -> float
         {

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -138,7 +138,6 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     // Positions and sizes
     static bool cameraButtonsCollapsed = windowsSettings.getSetting(m_name.c_str(), WS_VIEWPORT_CAMERABUTTONCOLLAPSE, true);
     const auto& wpos = ImGui::GetMainViewport()->Pos;
-    const auto& cwpos = ImGui::GetCurrentWindow()->Pos;
     auto position = ImGui::GetWindowPos();
     ImGui::GetCurrentWindow()->DC.CursorPos = position;
 
@@ -230,9 +229,8 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     // When clicking these buttons, the mouse only moves into the current window area
     // We allow the mouse to cross walls and reapear on the other side
     auto dpos = ImGui::GetIO().MouseDelta;
-    // Scale from MouseDelta to camera translation
-    dpos.x *= 0.2;
-    dpos.y *= 0.2;
+    // Scale from camera pixel to world displacement
+    dpos *= 1e-3;
 
     // Buttons
     ImVec2 buttonSize = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
@@ -324,9 +322,6 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
             ImGui::PopStyleColor();
 
             { // Axis related
-                // Compute scale based on distance. The further the camera, the faster the translation.
-                const float scale = camera->getDistance() * 0.002f;
-
                 { // Translate Left/Right
                     ImGui::LocalButton(ICON_FA_ARROWS_LEFT_RIGHT"##TranslateLR");
                     if (ImGui::IsItemActive())
@@ -334,7 +329,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
                         sofa::type::Vec3 t = sofa::type::Vec3(1., 0., 0.);
                         t = camera->cameraToWorldTransform(t);
                         t.normalize();
-                        t *= - dpos.x * scale;
+                        t *= - dpos.x * camera->getDistance(); // Compute scale based on distance. The further the camera, the faster the translation.
                         camera->translate(t);
                         camera->translateLookAt(t);
                         translate = true;
@@ -351,7 +346,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
                         sofa::type::Vec3 t = sofa::type::Vec3(0., 1., 0.);
                         t = camera->cameraToWorldTransform(t);
                         t.normalize();
-                        t *= dpos.y * scale;
+                        t *= dpos.y * camera->getDistance(); // Compute scale based on distance. The further the camera, the faster the translation.
                         camera->translate(t);
                         camera->translateLookAt(t);
                         translate = true;
@@ -368,8 +363,8 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
                         sofa::type::Vec3 t = sofa::type::Vec3(0., 0., 1.);
                         t = camera->cameraToWorldTransform(t);
                         t.normalize();
-                        const auto& mousedelta = dpos.x;
-                        t *= mousedelta * scale;
+                        const auto& mousedelta = dpos.x * camera->getDistance();
+                        t *= mousedelta;
                         camera->translate(t);
                         translate = true;
 
@@ -390,18 +385,17 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     bool rotate = false;
 
     { // Orientation gizmo clicked
-        float scale = 1e-3; // Mouse to rotation scale
-        auto getRotationCoef = [dpos, scale](sofa::type::Vec3 cpos) -> float
+        auto getRotationCoef = [dpos, camera](sofa::type::Vec3 axis) -> float
         {
-            return (cpos[1]*dpos.x - cpos[0]*dpos.y) / sqrt(cpos[0]*cpos[0] + cpos[1]*cpos[1]) * scale;
+            auto cpos = camera->worldToScreenPoint(axis);
+            return (cpos[1]*dpos.x - cpos[0]*dpos.y) / sqrt(cpos[0]*cpos[0] + cpos[1]*cpos[1]);
         };
 
         // Rotate X
         if (axisClicked[0])
         {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            auto xc = camera->worldToScreenPoint(sofa::type::Vec3(1, 0, 0));
-            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(getRotationCoef(xc), 0., 0., 1.);
+            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(getRotationCoef(sofa::type::Vec3(1., 0., 0.)), 0., 0., 1.);
             camera->rotateCameraAroundPoint(q, lookAt);
             rotate = true;
         }
@@ -409,8 +403,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         else if (axisClicked[1])
         {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            auto yc = camera->worldToScreenPoint(sofa::type::Vec3(0, 1, 0));
-            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., getRotationCoef(yc), 0., 1.);
+            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., getRotationCoef(sofa::type::Vec3(0., 1., 0.)), 0., 1.);
             camera->rotateCameraAroundPoint(q, lookAt);
             rotate = true;
         }
@@ -418,19 +411,18 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         else if (axisClicked[2])
         {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            auto zc = camera->worldToScreenPoint(sofa::type::Vec3(0, 0, 1));
-            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., 0., getRotationCoef(zc), 1.);
+            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., 0., getRotationCoef(sofa::type::Vec3(0., 0., 1.)), 1.);
             camera->rotateCameraAroundPoint(q, lookAt);
             rotate = true;
         }
-    }
 
-    if (rotate)
-    {
-        // TODO: This should be done in rotateCameraAroundPoint()
-        auto orientation = camera->getOrientation();
-        orientation.normalize();
-        camera->setView(lookAt - orientation.rotate(sofa::type::Vec3(0,0,-distance)), orientation);
+        if (rotate)
+        {
+            // TODO: This should be done in rotateCameraAroundPoint()
+            auto orientation = camera->getOrientation();
+            orientation.normalize();
+            camera->setView(lookAt - orientation.rotate(sofa::type::Vec3(0., 0., -distance)), orientation);
+        }
     }
 
     // Hides and grabs the cursor, providing virtual and unlimited cursor movement.

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -234,6 +234,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     dpos.y = dpos.y>=m_windowSize.second/2? m_windowSize.second-dpos.y: dpos.y;
     dpos.x = dpos.x<=-m_windowSize.first/2? -m_windowSize.first-dpos.x: dpos.x;
     dpos.y = dpos.y<=-m_windowSize.second/2? -m_windowSize.second-dpos.y: dpos.y;
+    // Scale from MouseDelta to camera translation
     dpos.x *= 0.2;
     dpos.y *= 0.2;
 
@@ -389,10 +390,9 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     }
 
     const auto& cpos = ImGui::GetIO().MousePos;
-    // When setting the mouse position, the value is relative to the window top left corner
-    // Thus we need to compute the shifts between this position and the top left corner of the current window area
-    const float xshift = (cwpos.x - wpos.x);
-    const float yshift = (cwpos.y - wpos.y);
+    // When setting the mouse position, the value is relative to the app window top left corner
+    // Thus we need to compute the offsets between this position and the top left corner of the current window (ViewportWindow)
+    const ImVec2 appOffset = cwpos - wpos;
 
     const double &distance = camera->getDistance();
     const sofa::type::Vec3 &lookAt = camera->getLookAtFromOrientation(camera->getPosition(), distance, camera->getOrientation()); // TODO: This should be initialize in BaseCamera
@@ -437,13 +437,13 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     if (rotate || translate)
     {
         if (cpos.x < cwpos.x)
-            baseGUI->setMousePos(xshift + m_windowSize.first, cpos.y - wpos.y);
+            baseGUI->setMousePos(appOffset.x + m_windowSize.first, cpos.y - wpos.y);
         if (cpos.x > cwpos.x + m_windowSize.first)
-            baseGUI->setMousePos(xshift, cpos.y - wpos.y);
+            baseGUI->setMousePos(appOffset.x, cpos.y - wpos.y);
         if (cpos.y < cwpos.y)
-            baseGUI->setMousePos(cpos.x - wpos.x, yshift + m_windowSize.second);
+            baseGUI->setMousePos(cpos.x - wpos.x, appOffset.y + m_windowSize.second);
         if (cpos.y > cwpos.y + m_windowSize.second)
-            baseGUI->setMousePos(cpos.x - wpos.x, yshift);
+            baseGUI->setMousePos(cpos.x - wpos.x, appOffset.y);
     }
 
     ImGui::PopStyleColor(2);

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -386,13 +386,18 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
 
         auto getRotationCoef = [dpos, camera](sofa::type::Vec3 axis) -> float
         {
-            auto spos = camera->worldToScreenPoint(axis);
-            if(sqrt(spos[0]*spos[0] + spos[1]*spos[1]) < 1e-10)
+            auto sorigin = camera->worldToScreenPoint(sofa::type::Vec3(0, 0, 0));
+            auto saxis = camera->worldToScreenPoint(axis);
+
+            ImVec2 spos(-(saxis[1]-sorigin[1]), (saxis[0]-sorigin[0])); // orthogonal axis in image coord
+
+
+            if(sqrt(spos.x*spos.x + spos.y*spos.y) < 1e-10)
             {
-                spos[0] = abs(dpos.y)>abs(dpos.x)? -1: 0;
-                spos[1] = abs(dpos.y)>abs(dpos.x)? 0: 1;
+                spos.x = abs(dpos.y)>abs(dpos.x)? 1: 0;
+                spos.y = abs(dpos.y)>abs(dpos.x)? 0: 1;
             }
-            return (spos[1]*dpos.x - spos[0]*dpos.y) / sqrt(spos[0]*spos[0] + spos[1]*spos[1]);
+            return (spos.x*dpos.x + spos.y*dpos.y) / sqrt(spos.x*spos.x + spos.y*spos.y);
         };
 
         // Rotate X

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -230,8 +230,12 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     // When clicking these buttons, the mouse only moves into the current window area
     // We allow the mouse to cross walls and reapear on the other side
     auto dpos = ImGui::GetIO().MouseDelta;
-    dpos.x = std::clamp(int(dpos.x), -20, 20); // Clamp the mouse delta, set the maximum speed
-    dpos.y = std::clamp(int(dpos.y), -20, 20);
+    dpos.x = dpos.x>=m_windowSize.first/2? m_windowSize.first-dpos.x: dpos.x;
+    dpos.y = dpos.y>=m_windowSize.second/2? m_windowSize.second-dpos.y: dpos.y;
+    dpos.x = dpos.x<=-m_windowSize.first/2? -m_windowSize.first-dpos.x: dpos.x;
+    dpos.y = dpos.y<=-m_windowSize.second/2? -m_windowSize.second-dpos.y: dpos.y;
+    dpos.x *= 0.2;
+    dpos.y *= 0.2;
 
     // Buttons
     ImVec2 buttonSize = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
@@ -435,7 +439,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         if (cpos.x < cwpos.x)
             baseGUI->setMousePos(xshift + m_windowSize.first, cpos.y - wpos.y);
         if (cpos.x > cwpos.x + m_windowSize.first)
-            baseGUI->setMousePos(xshift + buttonSize.x / 2., cpos.y - wpos.y);
+            baseGUI->setMousePos(xshift, cpos.y - wpos.y);
         if (cpos.y < cwpos.y)
             baseGUI->setMousePos(cpos.x - wpos.x, yshift + m_windowSize.second);
         if (cpos.y > cwpos.y + m_windowSize.second)

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -386,8 +386,13 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
 
         auto getRotationCoef = [dpos, camera](sofa::type::Vec3 axis) -> float
         {
-            auto cpos = camera->worldToScreenPoint(axis);
-            return (cpos[1]*dpos.x - cpos[0]*dpos.y) / sqrt(cpos[0]*cpos[0] + cpos[1]*cpos[1]);
+            auto spos = camera->worldToScreenPoint(axis);
+            if(sqrt(spos[0]*spos[0] + spos[1]*spos[1]) < 1e-10)
+            {
+                spos[0] = abs(dpos.y)>abs(dpos.x)? -1: 0;
+                spos[1] = abs(dpos.y)>abs(dpos.x)? 0: 1;
+            }
+            return (spos[1]*dpos.x - spos[0]*dpos.y) / sqrt(spos[0]*spos[0] + spos[1]*spos[1]);
         };
 
         // Rotate X
@@ -395,6 +400,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
             sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(getRotationCoef(sofa::type::Vec3(1., 0., 0.)), 0., 0., 1.);
+            q.normalize();
             camera->rotateCameraAroundPoint(q, lookAt);
             rotate = true;
         }
@@ -403,6 +409,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
             sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., getRotationCoef(sofa::type::Vec3(0., 1., 0.)), 0., 1.);
+            q.normalize();
             camera->rotateCameraAroundPoint(q, lookAt);
             rotate = true;
         }
@@ -411,6 +418,7 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
             sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., 0., getRotationCoef(sofa::type::Vec3(0., 0., 1.)), 1.);
+            q.normalize();
             camera->rotateCameraAroundPoint(q, lookAt);
             rotate = true;
         }

--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -230,10 +230,6 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     // When clicking these buttons, the mouse only moves into the current window area
     // We allow the mouse to cross walls and reapear on the other side
     auto dpos = ImGui::GetIO().MouseDelta;
-    dpos.x = dpos.x>=m_windowSize.first/2? m_windowSize.first-dpos.x: dpos.x;
-    dpos.y = dpos.y>=m_windowSize.second/2? m_windowSize.second-dpos.y: dpos.y;
-    dpos.x = dpos.x<=-m_windowSize.first/2? -m_windowSize.first-dpos.x: dpos.x;
-    dpos.y = dpos.y<=-m_windowSize.second/2? -m_windowSize.second-dpos.y: dpos.y;
     // Scale from MouseDelta to camera translation
     dpos.x *= 0.2;
     dpos.y *= 0.2;
@@ -389,21 +385,23 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         }
     }
 
-    const auto& cpos = ImGui::GetIO().MousePos;
-    // When setting the mouse position, the value is relative to the app window top left corner
-    // Thus we need to compute the offsets between this position and the top left corner of the current window (ViewportWindow)
-    const ImVec2 appOffset = cwpos - wpos;
-
     const double &distance = camera->getDistance();
     const sofa::type::Vec3 &lookAt = camera->getLookAtFromOrientation(camera->getPosition(), distance, camera->getOrientation()); // TODO: This should be initialize in BaseCamera
     bool rotate = false;
 
     { // Orientation gizmo clicked
+        float scale = 1e-3; // Mouse to rotation scale
+        auto getRotationCoef = [dpos, scale](sofa::type::Vec3 cpos) -> float
+        {
+            return (cpos[1]*dpos.x - cpos[0]*dpos.y) / sqrt(cpos[0]*cpos[0] + cpos[1]*cpos[1]) * scale;
+        };
+
         // Rotate X
         if (axisClicked[0])
         {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0.001 * dpos.x, 0., 0., 1.);
+            auto xc = camera->worldToScreenPoint(sofa::type::Vec3(1, 0, 0));
+            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(getRotationCoef(xc), 0., 0., 1.);
             camera->rotateCameraAroundPoint(q, lookAt);
             rotate = true;
         }
@@ -411,7 +409,8 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         else if (axisClicked[1])
         {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., 0.001 * dpos.x, 0., 1.);
+            auto yc = camera->worldToScreenPoint(sofa::type::Vec3(0, 1, 0));
+            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., getRotationCoef(yc), 0., 1.);
             camera->rotateCameraAroundPoint(q, lookAt);
             rotate = true;
         }
@@ -419,7 +418,8 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         else if (axisClicked[2])
         {
             ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
-            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., 0., 0.001 * dpos.x, 1.);
+            auto zc = camera->worldToScreenPoint(sofa::type::Vec3(0, 0, 1));
+            sofa::type::Quat<SReal> q = sofa::type::Quat<SReal>(0., 0., getRotationCoef(zc), 1.);
             camera->rotateCameraAroundPoint(q, lookAt);
             rotate = true;
         }
@@ -433,18 +433,8 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
         camera->setView(lookAt - orientation.rotate(sofa::type::Vec3(0,0,-distance)), orientation);
     }
 
-    // Allow the mouse to cross walls, and reapear on the other side of the current window area
-    if (rotate || translate)
-    {
-        if (cpos.x < cwpos.x)
-            baseGUI->setMousePos(appOffset.x + m_windowSize.first, cpos.y - wpos.y);
-        if (cpos.x > cwpos.x + m_windowSize.first)
-            baseGUI->setMousePos(appOffset.x, cpos.y - wpos.y);
-        if (cpos.y < cwpos.y)
-            baseGUI->setMousePos(cpos.x - wpos.x, appOffset.y + m_windowSize.second);
-        if (cpos.y > cwpos.y + m_windowSize.second)
-            baseGUI->setMousePos(cpos.x - wpos.x, appOffset.y);
-    }
+    // Hides and grabs the cursor, providing virtual and unlimited cursor movement.
+    baseGUI->setDisabledMouse(rotate || translate);
 
     ImGui::PopStyleColor(2);
     ImGui::PopStyleVar();


### PR DESCRIPTION
In this PR:
- add `setDisabledMouse` to use `GLFW_CURSOR_DISABLED` from glfw: allows for hiding and grabbing the cursor, providing virtual and unlimited cursor movement (instead of home made implementation)
- fixes rotation gizmo behavior
- initialize camera `lookAt` which fixes some bugs
- cleaning

https://github.com/user-attachments/assets/e75612ec-2039-47e2-b2d3-d7a98c1b3220

