### PR TITLE
[ViewMenu] always add origin frame at the beginning of the node

### DIFF
--- a/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
+++ b/SofaImGui/src/SofaImGui/menus/ViewMenu.cpp
@@ -161,7 +161,7 @@ void ViewMenu::showOriginFrame(const bool& show)
                 auto bboxSize = bbox.maxBBox() - bbox.minBBox();
                 auto lineSize = floor(*std::max_element(bboxSize.begin(), bboxSize.end()) * 10);
                 auto newOriginFrame = sofa::core::objectmodel::New<sofa::component::visual::LineAxis>();
-                guiNode->addObject(newOriginFrame);
+                guiNode->addObject(newOriginFrame, sofa::core::objectmodel::TypeOfInsertion::AtBegin);
                 newOriginFrame->setName("ViewportOriginFrame");
                 newOriginFrame->addTag(sofaglfw::SofaGLFWBaseGUI::getGUITag());
                 newOriginFrame->d_enable.setValue(show);


### PR DESCRIPTION
This avoid the frame to be hidden behind the grids.

<img width="3840" height="2233" alt="image" src="https://github.com/user-attachments/assets/e6923675-1c59-4a62-949f-7fc972c90bf1" />
