### PR TITLE
[ViewportWindow] Prevent from scrolling

### DIFF
--- a/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ViewportWindow.cpp
@@ -62,7 +62,7 @@ void ViewportWindow::showWindow(sofaglfw::SofaGLFWBaseGUI* baseGUI,
 
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen, windowFlags))
         {
-            ImGui::BeginChild("Render", ImVec2(0, 0), ImGuiChildFlags_None, ImGuiWindowFlags_NoScrollbar);
+            ImGui::BeginChild("Render", ImVec2(0, 0), ImGuiChildFlags_None, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
             {
                 ImVec2 viewportPos = ImGui::GetWindowPos();
                 baseGUI->updateViewportPosition(viewportPos.x, viewportPos.y);
@@ -219,7 +219,9 @@ void ViewportWindow::addCameraButtons(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::
     auto color = ImGui::GetStyle().Colors[ImGuiCol_TabActive];
     color.w = 0.6f;
     ImGui::PushClipRect(ImVec2(ImGui::GetWindowContentRegionMin().x, ImGui::GetWindowContentRegionMin().y),
-                        ImVec2(ImGui::GetWindowContentRegionMax().x + ImGui::GetWindowPos().x, ImGui::GetWindowContentRegionMax().y + ImGui::GetWindowPos().y - ImGui::GetStyle().FramePadding.y), true);
+                        ImVec2(ImGui::GetWindowContentRegionMax().x + ImGui::GetWindowPos().x,
+                               ImGui::GetWindowContentRegionMax().y + ImGui::GetWindowPos().y - ImGui::GetStyle().FramePadding.y),
+                        true);
     ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1); // Work around to add padding
     ImGui::PushStyleColor(ImGuiCol_ChildBg, ImGui::GetColorU32(color));
     ImGui::PushStyleColor(ImGuiCol_Border, ImGui::GetColorU32(color));


### PR DESCRIPTION
**Problem**
When the left camera buttons area was cropped, we could scroll the viewport. 
 
https://github.com/user-attachments/assets/de0f3f40-d2a9-4c10-8d6b-e8155b3ea1c0

**In this PR**
Disable scrolling.

https://github.com/user-attachments/assets/178d43d1-0cb2-4462-904b-7a6b2057d627

