### PR TITLE
[FooterStatusBar] Adds button to check logs based on messages type

### DIFF
--- a/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
+++ b/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
@@ -19,13 +19,15 @@
  *                                                                             *
  * Contact information: contact@sofa-framework.org                             *
  ******************************************************************************/
+
 #include "GUIColors.h"
 #include <IconsFontAwesome6.h>
 #include <SofaImGui/widgets/Widgets.h>
-#include <imgui_internal.h>
-#include <sofa/helper/system/FileSystem.h>
-#include <sofa/helper/logging/Messaging.h>
 #include <SofaImGui/FooterStatusBar.h>
+#include <imgui_internal.h>
+
+#include <sofa/helper/logging/Messaging.h>
+#include <sofa/helper/system/FileSystem.h>
 #include <sofa/version.h>
 
 #include <filesystem>
@@ -52,12 +54,15 @@ void FooterStatusBar::showFooterStatusBar()
             // Display the software version in the right of the status bar
             std::string version = "SOFA v" + std::string(SOFA_VERSION_STR);
             float length = ImGui::CalcTextSize(version.c_str()).x;
-            float right = ImGui::GetCursorPosX() + ImGui::GetWindowSize().x - length - 2 * ImGui::GetStyle().ItemSpacing.x;
-            ImGui::SetCursorPosX(right); // Set the position to the middle of the bar
+            float right = ImGui::GetCursorPosX() + ImGui::GetWindowSize().x - length - 2 * ImGui::GetStyle().ItemSpacing.x; // Set the position to the right of the bar
+            ImGui::SetCursorPosX(right);
             ImGui::TextDisabled("%s", version.c_str());
 
             ImGui::EndMenuBar();
         }
+
+        showLogStatus();
+
         ImGui::End();
     }
     ImGui::PopStyleColor();
@@ -215,6 +220,74 @@ void FooterStatusBar::setTempMessage(const std::string &message, const MessageTy
         break;
     }
     }
+}
+
+void FooterStatusBar::showLogStatus()
+{
+    // update log status if logs have changed
+    if (m_previousMessagesCount < m_messages.size())
+    {
+        auto higherStatus = std::max_element(m_messages.begin() + m_previousMessagesCount, 
+                                                m_messages.end(), 
+                                                [this](const auto& m1, const auto& m2) {return m1.type() < m2.type();}); // get max priority messsage
+        if(higherStatus->type() > m_logStatus)
+            m_logStatus = higherStatus->type();
+    }
+
+    // show button if needed
+    if (m_logStatus >= sofa::helper::logging::Message::Type::Deprecated)
+    {
+        if (ImGui::Begin("##FooterStatusBar"))
+        {
+            if (ImGui::BeginMenuBar())
+            {
+                const char* icon;
+                ImColor color;
+                if (m_logStatus >= sofa::helper::logging::Message::Type::Error) 
+                {
+                    icon = ICON_FA_CIRCLE_EXCLAMATION;
+                    color = ImColor(COLOR_RED);
+                }
+                else if (m_logStatus >= sofa::helper::logging::Message::Type::Warning) 
+                {
+                    icon = ICON_FA_TRIANGLE_EXCLAMATION;
+                    color = ImColor(COLOR_ORANGE);
+                }
+                else 
+                {
+                    icon = ICON_FA_CIRCLE_INFO;
+                    color = ImColor(COLOR_BLUE);
+                }
+                
+                float left = ImGui::GetStyle().ItemSpacing.x; // Set the position to the right of the bar
+                ImGui::SetCursorPosX(left);
+
+                ImGui::PushStyleColor(ImGuiCol_Button, COLOR_TRANSPARENT);
+                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, COLOR_TRANSPARENT);
+                ImGui::PushStyleColor(ImGuiCol_ButtonActive, COLOR_TRANSPARENT);
+                ImGui::PushStyleColor(ImGuiCol_ButtonText, color.Value);
+
+                if (ImGui::LocalButton(icon))
+                {
+                    m_logStatusOnClick();
+                }
+
+                ImGui::SetItemTooltip("Check the logs");
+
+                ImGui::PopStyleColor(4);
+
+                ImGui::EndMenuBar();
+            }
+            ImGui::End();
+        }
+    }
+
+    m_previousMessagesCount = m_messages.size();
+}
+
+void FooterStatusBar::setLogStatusCallback(std::function<void()> f)
+{
+    m_logStatusOnClick = f;
 }
 
 }

--- a/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
+++ b/SofaImGui/src/SofaImGui/FooterStatusBar.cpp
@@ -227,9 +227,9 @@ void FooterStatusBar::showLogStatus()
     // update log status if logs have changed
     if (m_previousMessagesCount < m_messages.size())
     {
-        auto higherStatus = std::max_element(m_messages.begin() + m_previousMessagesCount, 
-                                                m_messages.end(), 
-                                                [this](const auto& m1, const auto& m2) {return m1.type() < m2.type();}); // get max priority messsage
+        auto higherStatus = std::max_element(m_messages.begin() + m_previousMessagesCount,
+                                            m_messages.end(),
+                                            [](const auto& m1, const auto& m2) {return m1.type() < m2.type();}); // get max priority messsage
         if(higherStatus->type() > m_logStatus)
             m_logStatus = higherStatus->type();
     }
@@ -267,12 +267,14 @@ void FooterStatusBar::showLogStatus()
                 ImGui::PushStyleColor(ImGuiCol_ButtonActive, COLOR_TRANSPARENT);
                 ImGui::PushStyleColor(ImGuiCol_ButtonText, color.Value);
 
-                if (ImGui::LocalButton(icon))
+                if (ImGui::Button(icon))
                 {
-                    m_logStatusOnClick();
+                    m_logStatusCallback();
                 }
+                ImGui::SetItemTooltip("Open Log");
 
-                ImGui::SetItemTooltip("Check the logs");
+                ImGui::SameLine(0,0);
+                ImGui::TextDisabled("Check Logs");
 
                 ImGui::PopStyleColor(4);
 
@@ -287,7 +289,7 @@ void FooterStatusBar::showLogStatus()
 
 void FooterStatusBar::setLogStatusCallback(std::function<void()> f)
 {
-    m_logStatusOnClick = f;
+    m_logStatusCallback = f;
 }
 
 }

--- a/SofaImGui/src/SofaImGui/FooterStatusBar.h
+++ b/SofaImGui/src/SofaImGui/FooterStatusBar.h
@@ -58,7 +58,7 @@ protected:
 
     const std::vector<sofa::helper::logging::Message>& m_messages = sofa::helper::logging::MainLoggingMessageHandler::getInstance().getMessages();
     sofa::helper::logging::Message::Type m_logStatus = sofa::helper::logging::Message::Type::Info;
-    std::function<void()> m_logStatusOnClick = nullptr;
+    std::function<void()> m_logStatusCallback = nullptr;
     size_t m_previousMessagesCount = 0;
 
 };

--- a/SofaImGui/src/SofaImGui/FooterStatusBar.h
+++ b/SofaImGui/src/SofaImGui/FooterStatusBar.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <SofaImGui/config.h>
+#include <sofa/helper/logging/LoggingMessageHandler.h>
 #include <imgui.h>
 #include <string>
 
@@ -38,6 +39,9 @@ public:
     void showTempMessageOnStatusBar(); /// Show temporary info message in the middle of the status bar.
     void setTempMessage(const std::string &message, const MessageType &type=MessageType::MINFO, const std::string &path=""); /// Set the temporary info message
 
+    void showLogStatus();
+    void setLogStatusCallback(std::function<void()>);
+
 protected:
 
     void showPath();
@@ -51,6 +55,11 @@ protected:
 
     std::string m_fileToOpen;
     std::string m_fileToOpenPopUpLabel{"Open##FiletoTopen"};
+
+    const std::vector<sofa::helper::logging::Message>& m_messages = sofa::helper::logging::MainLoggingMessageHandler::getInstance().getMessages();
+    sofa::helper::logging::Message::Type m_logStatus = sofa::helper::logging::Message::Type::Info;
+    std::function<void()> m_logStatusOnClick = nullptr;
+    size_t m_previousMessagesCount = 0;
 
 };
 

--- a/SofaImGui/src/SofaImGui/windows/LogWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/LogWindow.cpp
@@ -44,8 +44,14 @@
 namespace sofaimgui::windows {
 
 LogWindow::LogWindow(const std::string& name, const bool& isWindowOpen)
-    : BaseWindow(name, isWindowOpen)
+    : BaseWindow(name, isWindowOpen), m_messages(sofa::helper::logging::MainLoggingMessageHandler::getInstance().getMessages())
 {
+    FooterStatusBar::getInstance().setLogStatusCallback(
+        [this]() {
+            this->setOpen(true);
+            ImGui::SetWindowFocus(this->getLabel().c_str());
+        }
+    );
 }
 
 std::string LogWindow::getDescription()
@@ -62,11 +68,10 @@ void LogWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWindow
         if (ImGui::Begin(getLabel().c_str(), &m_isOpen, windowFlags))
         {
             unsigned int i {};
-            const auto& messages = sofa::helper::logging::MainLoggingMessageHandler::getInstance().getMessages();
-            const int digits = [&messages]()
+            const int digits = [this]()
             {
                 int d = 0;
-                auto s = messages.size();
+                auto s = this->m_messages.size();
                 while (s != 0) { s /= 10; d++; }
                 return d;
             }();
@@ -104,7 +109,7 @@ void LogWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWindow
 
                     if (outputFile.is_open())
                     {
-                        for (const auto& message : messages)
+                        for (const auto& message : m_messages)
                         {
                             static std::unordered_map<sofa::helper::logging::Message::Type, std::string> labelMap {
                                     {sofa::helper::logging::Message::Advice, "SUGGESTION"},
@@ -144,7 +149,7 @@ void LogWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWindow
                 ImGui::TableSetupColumn("message type", ImGuiTableColumnFlags_WidthFixed);
                 ImGui::TableSetupColumn("sender", ImGuiTableColumnFlags_WidthFixed);
                 ImGui::TableSetupColumn("message", ImGuiTableColumnFlags_WidthStretch);
-                for (const auto& message : messages)
+                for (const auto& message : m_messages)
                 {
                     if (!showInfo && message.type() == sofa::helper::logging::Message::Info)
                     {

--- a/SofaImGui/src/SofaImGui/windows/LogWindow.h
+++ b/SofaImGui/src/SofaImGui/windows/LogWindow.h
@@ -42,5 +42,8 @@ namespace sofaimgui::windows
 
         void showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiWindowFlags &windowFlags) override;
         std::string getDescription() override;
+
+    private:
+        const std::vector<sofa::helper::logging::Message>& m_messages;
     };
 }


### PR DESCRIPTION
Implements #142 

This PR:
- Adds a button in the footer bar that opens the log window
- Changes the icon of this button based on the message type
- Adds log messages as class member in LogWindow for efficiency

<img  height="25" alt="image" src="https://github.com/user-attachments/assets/b8598d3a-e518-436c-a182-010e40813c5d" />

<img  height="25" alt="image" src="https://github.com/user-attachments/assets/8e938131-a6e7-4cbb-8d8c-c89ee4abfed7" />


<img  height="25" alt="image" src="https://github.com/user-attachments/assets/85937460-7194-4d99-b975-5fef5bdf394c" />



https://github.com/user-attachments/assets/c3634760-4981-4637-be48-e4ddf2f9548d

