### PR TITLE
[ProfilerWindow] Fixes profiler init by ensuring selectedframe is >= 0

### DIFF
--- a/SofaImGui/src/SofaImGui/windows/ProfilerWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProfilerWindow.cpp
@@ -107,7 +107,7 @@ void ProfilerWindow::showWindow(sofaglfw::SofaGLFWBaseGUI *baseGUI, const ImGuiW
                 ImGui::InputInt("##FrameInput", &m_selectedFrame);
                 ImGui::PopStyleVar();
                 ImGui::PopItemWidth();
-                m_selectedFrame = std::clamp(m_selectedFrame, 0, int(allRecords.size()) - 1);
+                m_selectedFrame = std::clamp(m_selectedFrame, 0, std::max(0, int(allRecords.size()) - 1));
                 ImGui::SameLine();
                 ImGui::TextDisabled("(duration in ms: %0.2f)", m_selectedFrameDuration);
 


### PR DESCRIPTION
On Windows, the profiler was glitchy before running the simulation.
It was because the clamp on `m_selectedFrame` was done between 0 and -1 when the records were empty (at init).

This PR fixes this.