### PR TITLE
[ProgramWindow] fixes #160

### DIFF
--- a/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
+++ b/SofaImGui/src/SofaImGui/windows/ProgramWindow.cpp
@@ -947,6 +947,8 @@ void ProgramWindow::animateBeginEvent(sofa::simulation::Node *groot)
 
         stepProgram(dt, reverse);
         m_time += dt; // for cursor display
+        m_cursorPos = m_time * ProgramSizes().TimelineOneSecondSize; // update the cursor position
+
     } // isDrivingSimulation
 }
 


### PR DESCRIPTION
**Problem**
The program stops when the window is hidden. The problem was introduced in #153. The time depends on the cursor position which was only updated when drawing the window. 

**Solution**
Update the cursor position at the end of the time step when the program is driving the simulation. 